### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ branches:
 os: Windows Server 2012
 install:
   - cmd: set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
-  - cmd: SET PATH=C:\Ruby23-x64\bin;%PATH%
+  - cmd: SET PATH=C:\Ruby24-x64\bin;%PATH%
   - cmd: ruby --version
   - cmd: git --version
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ branches:
     - gh-pages
 os: Windows Server 2012
 install:
+  - cmd: set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
   - cmd: SET PATH=C:\Ruby23-x64\bin;%PATH%
   - cmd: ruby --version
   - cmd: git --version


### PR DESCRIPTION
as per https://www.appveyor.com/docs/lang/ruby/

### OpenSSL Verification
OpenSSL needs a cert file to verify a site’s certificate. First, Ruby looks to ```ENV['SSL_CERT_FILE']```, and then looks to the ```OpenSSL::X509::DEFAULT_CERT_FILE``` constant. If neither point to a valid cert file, no verification can be performed.

Ruby RI builds do not properly set the constant, and the ENV variable is not set in the default Appveyor environment.

Conversely, Ruby RI2 builds are packaged with a cert file, and the constant is properly set.

Hence, to allow for SSL verification using RI builds (2.3 and earlier), you can either:

- Use set ```SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem```

- Download https://curl.haxx.se/ca/cacert.pem and store it somewhere, then set ```SSL_CERT_FILE``` to its full path.

Also Ruby 2.4 is required, otherwise ```/^[0-9]+$/.match?(amount)``` fails