### PR TITLE
feat: #18 add --trust to require minimum confirmations on utxos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ It is recommended to run it with `--dry --verbose` options first,
 If everything looks correct, remove the `--dry` and run again,
   the transaction is pushed to the network.
 
+To require a minimum number of confirmations on every UTXO before it is
+  spent, or before it counts toward the reported balance, pass `--trust`:
+
+```bash
+sibit --trust=6 balance 1PfsYNygsuVL8fvBarJNQnHytkg4rGih1U
+sibit --trust=6 pay 10000 S P1,P2 TARGET CHANGE
+```
+
+The default is `0`, which preserves the existing behavior.
+The same option is available from the Ruby SDK via the `trust:` keyword
+  argument on `Sibit#balance` and `Sibit#pay`.
+
 To use an HTTPS proxy for all requests:
 
 ```bash

--- a/lib/sibit.rb
+++ b/lib/sibit.rb
@@ -62,10 +62,16 @@ class Sibit
     Key.new(pvt).bech32
   end
 
-  # Gets the balance of the address, in satoshi.
-  def balance(address)
+  # Gets the balance of the address, in satoshi. When +trust+ is greater
+  # than zero, only UTXOs with at least that many confirmations are summed,
+  # which requires the underlying API to support +utxos+.
+  def balance(address, trust: 0)
     raise(Error, "Invalid address #{address.inspect}") unless /^[0-9a-zA-Z]+$/.match?(address)
-    @api.balance(address)
+    unless trust.is_a?(Integer) && !trust.negative?
+      raise(Error, "Trust must be a non-negative Integer, got #{trust.inspect}")
+    end
+    return @api.balance(address) if trust.zero?
+    @api.utxos([address]).sum { |u| (u[:confirmations] || 0) >= trust ? u[:value] : 0 }
   end
 
   # Get the height of the block.
@@ -106,7 +112,7 @@ class Sibit
   # +price+: optional BTC price in USD (skips API fetch if provided)
   def pay(
     amount, fee, sources, target, change, skip_utxo: [], network: nil, base58: false,
-    price: nil
+    price: nil, trust: 0
   )
     unless amount.is_a?(Integer) || amount.is_a?(String)
       raise(Error, "The amount #{amount.inspect} must be Integer or String")
@@ -115,6 +121,9 @@ class Sibit
     raise(Error, 'The sources must be an Array') unless sources.is_a?(Array)
     raise(Error, 'The target must be a String') unless target.is_a?(String)
     raise(Error, 'The change must be a String') unless change.is_a?(String)
+    unless trust.is_a?(Integer) && !trust.negative?
+      raise(Error, "Trust must be a non-negative Integer, got #{trust.inspect}")
+    end
     p = price || price('USD')
     keys =
       sources.map do |k|
@@ -150,6 +159,10 @@ class Sibit
       end
       unless utxo[:confirmations]&.positive?
         @log.debug("UTXO with no confirmations: #{utxo[:hash]}")
+        next
+      end
+      if utxo[:confirmations] < trust
+        @log.debug("UTXO below trust=#{trust} (#{utxo[:confirmations]} conf): #{utxo[:hash]}")
         next
       end
       unspent += utxo[:value]

--- a/lib/sibit/bin.rb
+++ b/lib/sibit/bin.rb
@@ -83,8 +83,10 @@ class Sibit
     end
 
     desc 'balance ADDRESS', 'Check the balance of the Bitcoin address'
+    option :trust, type: :numeric, default: 0,
+      desc: 'Minimum number of confirmations required for a UTXO to count toward the balance'
     def balance(address)
-      log.info(client.balance(address))
+      log.info(client.balance(address, trust: options[:trust]))
     end
 
     desc \
@@ -95,6 +97,8 @@ class Sibit
     option :yes, type: :boolean, default: false,
       desc: 'Skip confirmation prompt and send the payment immediately'
     option :price, type: :numeric, desc: 'BTC price in USD (skips API price fetch if provided)'
+    option :trust, type: :numeric, default: 0,
+      desc: 'Minimum number of confirmations required on a UTXO before it can be spent'
     def pay(amount, fee, sources, target, change)
       keys = sources.split(',')
       if amount.upcase == 'MAX'
@@ -103,12 +107,15 @@ class Sibit
             kk = Sibit::Key.new(k)
             options[:base58] ? kk.base58 : kk.bech32
           end
-        amount = addrs.sum { |a| client.balance(a) }
+        amount = addrs.sum { |a| client.balance(a, trust: options[:trust]) }
       end
       amount = Integer(amount, 10) if amount.is_a?(String) && /^[0-9]+$/.match?(amount)
       fee = Integer(fee, 10) if /^[0-9]+$/.match?(fee)
       args = [amount, fee, keys, target, change]
-      kwargs = { skip_utxo: options[:skip_utxo], base58: options[:base58], price: options[:price] }
+      kwargs = {
+        skip_utxo: options[:skip_utxo], base58: options[:base58],
+        price: options[:price], trust: options[:trust]
+      }
       unless options[:yes] || options[:dry]
         client(dry: true).pay(*args, **kwargs)
         print('Do you confirm this payment? (yes/no): ')

--- a/test/test_sibit.rb
+++ b/test/test_sibit.rb
@@ -158,6 +158,69 @@ class TestSibit < Minitest::Test
     end
   end
 
+  def test_balance_with_trust_sums_confirmed_utxos
+    json = {
+      unspent_outputs: [
+        { tx_hash_big_endian: 'a' * 64, tx_output_n: 0, script: '', confirmations: 0, value: 11 },
+        { tx_hash_big_endian: 'b' * 64, tx_output_n: 0, script: '', confirmations: 2, value: 22 },
+        { tx_hash_big_endian: 'c' * 64, tx_output_n: 0, script: '', confirmations: 7, value: 44 }
+      ]
+    }
+    stub_request(
+      :get,
+      'https://blockchain.info/unspent?active=1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f&limit=1000'
+    ).to_return(body: JSON.pretty_generate(json))
+    sibit = Sibit.new(api: Sibit::Blockchain.new)
+    assert_equal(44, sibit.balance('1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f', trust: 3))
+  end
+
+  def test_balance_default_trust_uses_api_balance
+    stub_request(
+      :get,
+      'https://blockchain.info/rawaddr/1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f?limit=0'
+    ).to_return(body: '{"final_balance": 999}')
+    assert_equal(999, Sibit.new.balance('1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'))
+  end
+
+  def test_balance_rejects_negative_trust
+    sibit = Sibit.new(api: Sibit::Fake.new)
+    assert_raises(Sibit::Error) { sibit.balance('1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f', trust: -1) }
+  end
+
+  def test_send_payment_skips_utxo_below_trust
+    stub_request(
+      :get, 'https://api.blockchain.info/mempool/fees'
+    ).to_return(body: '{"regular":300,"priority":200,"limits":{"max":88}}')
+    stub_request(
+      :get, 'https://blockchain.info/ticker'
+    ).to_return(body: '{"USD" : {"15m" : 5160.04}}')
+    json = {
+      unspent_outputs: [
+        {
+          tx_hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+          tx_hash_big_endian: '5de641d3867eb8fec3eb1a5ef2b44df39b54e0b3bb664ab520f2ae26a5b18ffc',
+          tx_output_n: 0,
+          script: '0014c48a1737b35a9f9d9e3b624a910f1e22f7e80bbc',
+          confirmations: 1,
+          value: 100_000
+        }
+      ]
+    }
+    stub_request(
+      :get,
+      'https://blockchain.info/unspent?active=bc1qcj9pwdant20em83mvf9fzrc7ytm7szau5ysh9x&limit=1000'
+    ).to_return(body: JSON.pretty_generate(json))
+    sibit = Sibit.new(api: Sibit::FirstOf.new([Sibit::Blockchain.new]))
+    assert_raises(Sibit::Error) do
+      sibit.pay(
+        '0.0001BTC', 'S+',
+        ['fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2'],
+        sibit.create(sibit.generate), sibit.create(sibit.generate),
+        trust: 6
+      )
+    end
+  end
+
   def test_scan
     api = Object.new
     def api.block(hash)


### PR DESCRIPTION
Adds a `trust` keyword argument and a matching `--trust N` CLI option that requires every UTXO to carry at least N confirmations before it is spent by `pay`, or summed by `balance`. The default remains `0`, so existing scripts keep their current behavior. With `trust: N` set, `Sibit#balance` falls back to summing the qualifying outputs from `@api.utxos([address])`, which means the call requires the underlying API to support `utxos`.

The CLI now accepts `sibit --trust=6 balance ADDR` and `sibit --trust=6 pay ...`; the `pay MAX` shortcut also passes the same trust threshold through to the underlying `balance` lookups so the sum is consistent with what the payment loop will actually spend. The README is updated with one short example.

Verified with `bundle exec ruby -Ilib -Itest test/test_sibit.rb` (14 passes, 41 assertions, 0 failures, 0 errors) and `bundle exec rubocop lib/sibit.rb lib/sibit/bin.rb test/test_sibit.rb` (no offenses). The `donce`-based cross-distro tests in `test/test_cross.rb` were skipped because the sandbox has no Docker daemon, but they are unrelated to this change.

Closes #18
