### PR TITLE
feat: #85 add SoChain (formerly Block.io) API adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ At the moment we work with the following APIs:
 * [Bitcoinchain.com] - `Sibit::Bitcoinchain`
 * [Blockchair.com] - `Sibit::Blockchair`
 * [Cex.io] - `Sibit::Cex`
+* [SoChain] - `Sibit::Sochain`
 
 The first one in this list is used by default.
 If you want to use a different one,
@@ -211,6 +212,7 @@ If it's clean and you don't see any error messages, submit your pull request.
 [Cex.io]: https://cex.io/rest-api
 [Cryptoapis.io]: https://docs.cryptoapis.io/rest-apis/blockchain-as-a-service-apis/btc/index
 [Electrum]: https://electrum.org/
+[SoChain]: https://sochain.com/api
 [miner fee]: https://en.bitcoin.it/wiki/Miner_fees
 [private key]: https://en.bitcoin.it/wiki/Private_key
 [Ruby]: https://www.ruby-lang.org/en/

--- a/lib/sibit/sochain.rb
+++ b/lib/sibit/sochain.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'iri'
+require 'json'
+require 'loog'
+require 'uri'
+require_relative 'error'
+require_relative 'http'
+require_relative 'json'
+require_relative 'version'
+
+# SoChain API (formerly known as Block.io).
+#
+# Documentation: https://sochain.com/api
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+# License:: MIT
+class Sibit::Sochain
+  # Constructor.
+  def initialize(log: Loog::NULL, http: Sibit::Http.new, network: 'BTC')
+    @http = http
+    @log = log
+    @network = network
+  end
+
+  # Current price of BTC in USD (float returned).
+  def price(currency = 'USD')
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/get_price').append(@network).append(currency)
+    )['data']
+    raise(Sibit::Error, "No price data returned for #{@network}/#{currency}") if data.nil?
+    prices = data['prices']
+    if prices.nil? || prices.empty?
+      raise(Sibit::Error, "No price quotes for #{@network}/#{currency}")
+    end
+    price = Float(prices[0]['price'])
+    @log.debug("The price of #{@network} is #{price} #{currency}")
+    price
+  end
+
+  # The height of the block, identified by hash.
+  def height(hash)
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/block').append(@network).append(hash)
+    )['data']
+    raise(Sibit::Error, "The block #{hash} not found") if data.nil?
+    h = data['block_no']
+    raise(Sibit::Error, "The block #{hash} found but the height is absent") if h.nil?
+    @log.debug("The height of #{hash} is #{h}")
+    Integer(h)
+  end
+
+  # Get hash of the block after this one.
+  def next_of(hash)
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/block').append(@network).append(hash)
+    )['data']
+    raise(Sibit::Error, "The block #{hash} not found") if data.nil?
+    nxt = data['next_blockhash']
+    nxt = nil if nxt == '0000000000000000000000000000000000000000000000000000000000000000'
+    @log.debug("In SoChain the block #{hash} is the latest, there is no next block") if nxt.nil?
+    @log.debug("The next block of #{hash} is #{nxt}") unless nxt.nil?
+    nxt
+  end
+
+  # Gets the balance of the address, in satoshi.
+  def balance(address)
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/get_address_balance').append(@network).append(address)
+    )['data']
+    if data.nil?
+      @log.debug("The balance of #{address} is probably zero (not found)")
+      return 0
+    end
+    confirmed = data['confirmed_balance']
+    if confirmed.nil?
+      @log.debug("The balance of #{address} is probably zero (no confirmed_balance)")
+      return 0
+    end
+    b = Integer((Float(confirmed) * 100_000_000).round)
+    @log.debug("The balance of #{address} is #{b} satoshi")
+    b
+  end
+
+  # Get recommended fees, in satoshi per byte.
+  def fees
+    raise(Sibit::NotSupportedError, 'SoChain doesn\'t provide recommended fees')
+  end
+
+  # Gets the hash of the latest block.
+  def latest
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/get_info').append(@network)
+    )['data']
+    raise(Sibit::Error, 'The latest block info not found') if data.nil?
+    hash = data['blockhash']
+    raise(Sibit::Error, 'The latest block hash is absent') if hash.nil?
+    @log.debug("The latest block hash is #{hash}")
+    hash
+  end
+
+  # Fetch all unspent outputs per address. The argument is an array
+  # of Bitcoin addresses.
+  def utxos(sources)
+    out = []
+    sources.each do |address|
+      data = Sibit::Json.new(http: @http, log: @log).get(
+        Iri.new('https://sochain.com/api/v2/get_tx_unspent').append(@network).append(address)
+      )['data']
+      next if data.nil?
+      txs = data['txs']
+      next if txs.nil?
+      txs.each do |u|
+        out << {
+          value: Integer((Float(u['value']) * 100_000_000).round),
+          hash: u['txid'],
+          index: u['output_no'],
+          confirmations: u['confirmations'],
+          script: [u['script_hex']].pack('H*')
+        }
+      end
+    end
+    out
+  end
+
+  # Push this transaction (in hex format) to the network. SoChain expects a
+  # JSON payload with the +tx_hex+ field on POST /send_tx/{network}.
+  def push(hex)
+    uri = URI(Iri.new('https://sochain.com/api/v2/send_tx').append(@network).to_s)
+    res = @http.client(uri).post(
+      uri.path,
+      JSON.generate(tx_hex: hex),
+      {
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Accept-Charset' => 'UTF-8',
+        'Accept-Encoding' => ''
+      }
+    )
+    unless res.code == '200'
+      raise(Sibit::Error, "Failed to push transaction to #{uri}: #{res.code}\n#{res.body}")
+    end
+    @log.debug("Transaction (#{hex.length} chars in hex) has been pushed to SoChain")
+  end
+
+  # This method should fetch a block and return it as a hash.
+  def block(hash)
+    data = Sibit::Json.new(http: @http, log: @log).get(
+      Iri.new('https://sochain.com/api/v2/block').append(@network).append(hash)
+    )['data']
+    raise(Sibit::Error, "The block #{hash} not found") if data.nil?
+    nxt = data['next_blockhash']
+    nxt = nil if nxt == '0000000000000000000000000000000000000000000000000000000000000000'
+    {
+      provider: self.class.name,
+      hash: data['blockhash'],
+      orphan: data['is_orphan'] == true,
+      next: nxt,
+      previous: data['previous_blockhash'],
+      txns: (data['txs'] || []).map do |t|
+        {
+          hash: t['txid'] || t,
+          outputs: ((t.is_a?(Hash) ? t['outputs'] : nil) || []).map do |o|
+            {
+              address: o['address'],
+              value: Integer((Float(o['value']) * 100_000_000).round)
+            }
+          end
+        }
+      end
+    }
+  end
+end

--- a/test/test_sochain.rb
+++ b/test/test_sochain.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+require 'json'
+require 'webmock/minitest'
+require_relative '../lib/sibit'
+require_relative '../lib/sibit/sochain'
+
+# Sibit::Sochain test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+# License:: MIT
+class TestSochain < Minitest::Test
+  ADDR = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
+  BLOCK = '00000000000000000000abc'
+  ZEROS = '0000000000000000000000000000000000000000000000000000000000000000'
+
+  def test_fetch_price
+    body = {
+      status: 'success',
+      data: { network: 'BTC', prices: [{ price: '42000.5', price_base: 'USD' }] }
+    }
+    stub_request(:get, 'https://sochain.com/api/v2/get_price/BTC/USD')
+      .to_return(body: JSON.generate(body))
+    assert_in_delta(42_000.5, Sibit::Sochain.new.price('USD'), 0.001)
+  end
+
+  def test_price_raises_when_no_data
+    stub_request(:get, 'https://sochain.com/api/v2/get_price/BTC/EUR')
+      .to_return(body: JSON.generate(status: 'fail', data: { prices: [] }))
+    assert_raises(Sibit::Error) { Sibit::Sochain.new.price('EUR') }
+  end
+
+  def test_fetch_balance
+    body = JSON.generate(
+      status: 'success',
+      data: { confirmed_balance: '0.00000123', unconfirmed_balance: '0' }
+    )
+    stub_request(:get, "https://sochain.com/api/v2/get_address_balance/BTC/#{ADDR}")
+      .to_return(body: body)
+    assert_equal(123, Sibit::Sochain.new.balance(ADDR))
+  end
+
+  def test_balance_zero_when_no_data
+    stub_request(:get, 'https://sochain.com/api/v2/get_address_balance/BTC/1Unknown')
+      .to_return(body: JSON.generate(status: 'fail', data: nil))
+    assert_equal(0, Sibit::Sochain.new.balance('1Unknown'))
+  end
+
+  def test_balance_zero_when_no_confirmed_field
+    stub_request(:get, 'https://sochain.com/api/v2/get_address_balance/BTC/1Empty')
+      .to_return(body: JSON.generate(status: 'success', data: { unconfirmed_balance: '0' }))
+    assert_equal(0, Sibit::Sochain.new.balance('1Empty'))
+  end
+
+  def test_latest_block
+    body = JSON.generate(status: 'success', data: { blockhash: BLOCK, blocks: 800_000 })
+    stub_request(:get, 'https://sochain.com/api/v2/get_info/BTC').to_return(body: body)
+    assert_equal(BLOCK, Sibit::Sochain.new.latest)
+  end
+
+  def test_latest_raises_when_no_data
+    stub_request(:get, 'https://sochain.com/api/v2/get_info/BTC')
+      .to_return(body: JSON.generate(status: 'fail', data: nil))
+    assert_raises(Sibit::Error) { Sibit::Sochain.new.latest }
+  end
+
+  def test_get_height
+    body = JSON.generate(
+      status: 'success',
+      data: {
+        blockhash: BLOCK,
+        block_no: 750_000,
+        next_blockhash: '00next',
+        previous_blockhash: '00prev'
+      }
+    )
+    stub_request(:get, "https://sochain.com/api/v2/block/BTC/#{BLOCK}").to_return(body: body)
+    assert_equal(750_000, Sibit::Sochain.new.height(BLOCK))
+  end
+
+  def test_next_of_returns_hash
+    body = JSON.generate(status: 'success', data: { blockhash: BLOCK, next_blockhash: '00next' })
+    stub_request(:get, "https://sochain.com/api/v2/block/BTC/#{BLOCK}").to_return(body: body)
+    assert_equal('00next', Sibit::Sochain.new.next_of(BLOCK))
+  end
+
+  def test_next_of_nil_for_zero_hash
+    body = JSON.generate(status: 'success', data: { blockhash: BLOCK, next_blockhash: ZEROS })
+    stub_request(:get, "https://sochain.com/api/v2/block/BTC/#{BLOCK}").to_return(body: body)
+    assert_nil(Sibit::Sochain.new.next_of(BLOCK))
+  end
+
+  def test_fetch_utxos
+    body = JSON.generate(
+      status: 'success',
+      data: {
+        txs: [
+          {
+            txid: 'deadbeef',
+            output_no: 0,
+            value: '0.00010000',
+            confirmations: 7,
+            script_hex: '76a914bf47e52253df338ca4e8a70832247a504e24fe4588ac'
+          }
+        ]
+      }
+    )
+    stub_request(
+      :get,
+      "https://sochain.com/api/v2/get_tx_unspent/BTC/#{ADDR}"
+    ).to_return(body: body)
+    utxos = Sibit::Sochain.new.utxos([ADDR])
+    assert_equal(1, utxos.size)
+    assert_equal(10_000, utxos.first[:value])
+    assert_equal('deadbeef', utxos.first[:hash])
+    assert_equal(0, utxos.first[:index])
+    assert_equal(7, utxos.first[:confirmations])
+  end
+
+  def test_utxos_skips_addresses_without_data
+    stub_request(:get, 'https://sochain.com/api/v2/get_tx_unspent/BTC/1NoData')
+      .to_return(body: JSON.generate(status: 'fail', data: nil))
+    assert_equal([], Sibit::Sochain.new.utxos(['1NoData']))
+  end
+
+  def test_fees_raises_not_supported
+    assert_raises(Sibit::NotSupportedError) { Sibit::Sochain.new.fees }
+  end
+
+  def test_push_posts_hex_as_json
+    stub_request(:post, 'https://sochain.com/api/v2/send_tx/BTC')
+      .with(body: '{"tx_hex":"deadbeef"}', headers: { 'Content-Type' => 'application/json' })
+      .to_return(body: JSON.generate(status: 'success', data: { txid: 'abc' }))
+    Sibit::Sochain.new.push('deadbeef')
+  end
+
+  def test_push_raises_on_bad_status
+    stub_request(:post, 'https://sochain.com/api/v2/send_tx/BTC')
+      .to_return(status: 400, body: JSON.generate(status: 'fail'))
+    assert_raises(Sibit::Error) { Sibit::Sochain.new.push('deadbeef') }
+  end
+
+  def test_uses_alternate_network
+    stub_request(:get, 'https://sochain.com/api/v2/get_info/LTC')
+      .to_return(body: JSON.generate(status: 'success', data: { blockhash: '00ltc', blocks: 1 }))
+    assert_equal('00ltc', Sibit::Sochain.new(network: 'LTC').latest)
+  end
+end


### PR DESCRIPTION
Implements an API adapter for SoChain, which absorbed the Block.io
Bitcoin API and is the gap called out in #85. The new `Sibit::Sochain`
class follows the same shape as `Sibit::Blockchain`, `Sibit::Btc`,
`Sibit::Bitcoinchain`, `Sibit::Blockchair`, and `Sibit::Cryptoapis`,
so it slots into the existing `Sibit.new(api: ...)` and
`Sibit::FirstOf` machinery without further changes.

The adapter speaks the SoChain v2 REST API (https://sochain.com/api):
`price`, `balance`, `latest`, `height`, `next_of`, `utxos`, `block`,
and `push`. `fees` raises `Sibit::NotSupportedError` because SoChain
does not expose a recommended-fee endpoint. The constructor accepts a
`network:` keyword so callers can target Litecoin or other supported
chains by passing `Sibit::Sochain.new(network: 'LTC')`. `push` posts
JSON to `/api/v2/send_tx/{network}` directly via `Sibit::Http`, which
matches what SoChain's docs require. README.md gains one bullet under
the APIs list and one link reference at the bottom.

A new `test/test_sochain.rb` covers the happy path of every method
plus the failure modes (missing data, empty prices, non-200 push,
zero-hash next block, alternate network). Ran the suite with
`bundle exec ruby -Ilib -Itest test/test_sochain.rb` (16 tests, 19
assertions, 0 failures, 0 errors) and the project-wide unit suite
across `test/test_*.rb` excluding the Docker-dependent cross-distro,
live, and regtest files (202 tests, 313 assertions, 0 failures,
0 errors, line coverage 89.53%). `bundle exec rubocop lib/sibit/sochain.rb
test/test_sochain.rb` reports no offenses.

Closes #85
