### PR TITLE
fix: #245 accumulate Btc#utxos into separate array

### DIFF
--- a/lib/sibit/btc.rb
+++ b/lib/sibit/btc.rb
@@ -94,21 +94,21 @@ class Sibit::Btc
 
   # Fetch all unspent outputs per address.
   def utxos(sources)
-    txns = []
+    results = []
     sources.each do |hash|
       data = Sibit::Json.new(http: @http, log: @log).get(
         Iri.new('https://chain.api.btc.com/v3/address').append(hash).append('unspent')
       )['data']
       raise(Sibit::Error, "The address #{hash} not found") if data.nil?
-      txns = data['list']
-      next if txns.nil?
-      txns.each do |u|
+      list = data['list']
+      next if list.nil?
+      list.each do |u|
         outs = Sibit::Json.new(http: @http, log: @log).get(
           Iri.new('https://chain.api.btc.com/v3/tx').append(u['tx_hash']).add(verbose: 3)
         )['data']['outputs']
         outs.each_with_index do |o, i|
           next unless o['addresses'].include?(hash)
-          txns << {
+          results << {
             value: o['value'],
             hash: u['tx_hash'],
             index: i,
@@ -118,7 +118,7 @@ class Sibit::Btc
         end
       end
     end
-    txns
+    results
   end
 
   # Push this transaction (in hex format) to the network.

--- a/test/test_btc.rb
+++ b/test/test_btc.rb
@@ -196,4 +196,56 @@ class TestBtc < Minitest::Test
     sibit = Sibit::Btc.new
     assert_raises(Sibit::Error) { sibit.block(hash) }
   end
+
+  def test_utxos_accumulates_across_addresses
+    alpha = '1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    beta = '1BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{alpha}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"aaaa","confirmations":3}]}}')
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{beta}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"bbbb","confirmations":7}]}}')
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/aaaa?verbose=3').to_return(
+      body: %({"data":{"outputs":[{"addresses":["#{alpha}"],"value":100,"script_hex":"dead"}]}})
+    )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/bbbb?verbose=3').to_return(
+      body: %({"data":{"outputs":[{"addresses":["#{beta}"],"value":200,"script_hex":"cafe"}]}})
+    )
+    utxos = Sibit::Btc.new.utxos([alpha, beta])
+    assert_equal(2, utxos.length)
+    assert_equal(%w[aaaa bbbb], utxos.map { |u| u[:hash] })
+    assert_equal([100, 200], utxos.map { |u| u[:value] })
+    assert_equal([3, 7], utxos.map { |u| u[:confirmations] })
+    utxos.each { |u| assert_kind_of(Integer, u[:index]) }
+  end
+
+  def test_utxos_skips_outputs_for_other_addresses
+    mine = '1CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+    other = '1DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{mine}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"cccc","confirmations":1}]}}')
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/cccc?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[
+          {"addresses":["#{other}"],"value":50,"script_hex":"00"},
+          {"addresses":["#{mine}"],"value":75,"script_hex":"11"}
+        ]}})
+      )
+    utxos = Sibit::Btc.new.utxos([mine])
+    assert_equal(1, utxos.length)
+    assert_equal(75, utxos[0][:value])
+    assert_equal(1, utxos[0][:index])
+  end
+
+  def test_utxos_returns_empty_when_list_missing
+    mine = '1EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{mine}/unspent")
+      .to_return(body: '{"data":{}}')
+    assert_empty(Sibit::Btc.new.utxos([mine]))
+  end
+
+  def test_utxos_raises_when_data_missing
+    mine = '1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{mine}/unspent").to_return(body: '{}')
+    assert_raises(Sibit::Error) { Sibit::Btc.new.utxos([mine]) }
+  end
 end


### PR DESCRIPTION
Closes #245. `Sibit::Btc#utxos` was both overwriting its accumulator on every address loop (line 103 replaced the prior `[]` with the raw API response) and mutating that same array during the inner `txns.each` iteration. The result was a mixed list of API rows and projected UTXO hashes that did not match the contract honored by `Sibit::Blockchain#utxos`.

Renamed the inner local to `list`, accumulated projected hashes into a fresh `results` array, and returned `results` at the end. Callers now receive a clean `value/hash/index/confirmations/script` list shape across any number of source addresses, with no mid-iteration mutation.

Ran `bundle exec ruby -Ilib -Itest test/test_btc.rb` (25 tests, 43 assertions, 0 failures) and `bundle exec ruby -e "require 'rake'; load 'Rakefile'; Rake::Task['rubocop'].invoke"` (56 files, no offenses). Added four new tests covering accumulation across addresses, filtering of outputs that belong to other addresses, the missing-list branch, and the missing-data error path.
