### PR TITLE
fix: #245 accumulate utxos separately in Sibit::Btc#utxos

### DIFF
--- a/lib/sibit/btc.rb
+++ b/lib/sibit/btc.rb
@@ -94,21 +94,21 @@ class Sibit::Btc
 
   # Fetch all unspent outputs per address.
   def utxos(sources)
-    txns = []
+    results = []
     sources.each do |hash|
       data = Sibit::Json.new(http: @http, log: @log).get(
         Iri.new('https://chain.api.btc.com/v3/address').append(hash).append('unspent')
       )['data']
       raise(Sibit::Error, "The address #{hash} not found") if data.nil?
-      txns = data['list']
-      next if txns.nil?
-      txns.each do |u|
+      list = data['list']
+      next if list.nil?
+      list.each do |u|
         outs = Sibit::Json.new(http: @http, log: @log).get(
           Iri.new('https://chain.api.btc.com/v3/tx').append(u['tx_hash']).add(verbose: 3)
         )['data']['outputs']
         outs.each_with_index do |o, i|
           next unless o['addresses'].include?(hash)
-          txns << {
+          results << {
             value: o['value'],
             hash: u['tx_hash'],
             index: i,
@@ -118,7 +118,7 @@ class Sibit::Btc
         end
       end
     end
-    txns
+    results
   end
 
   # Push this transaction (in hex format) to the network.

--- a/test/test_btc.rb
+++ b/test/test_btc.rb
@@ -187,6 +187,81 @@ class TestBtc < Minitest::Test
     assert_nil(Sibit::Btc.new.block(hash)[:next], 'next should be nil for latest block')
   end
 
+  def test_fetch_utxos_for_single_address
+    addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"aa","confirmations":5}]}}'
+      )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[{"addresses":["#{addr}"],"value":42,"script_hex":"00"}]}})
+      )
+    utxos = Sibit::Btc.new.utxos([addr])
+    assert_kind_of(Array, utxos)
+    assert_equal(1, utxos.length)
+    out = utxos[0]
+    assert_equal(42, out[:value])
+    assert_equal('aa', out[:hash])
+    assert_equal(0, out[:index])
+    assert_equal(5, out[:confirmations])
+    assert_kind_of(String, out[:script])
+  end
+
+  def test_fetch_utxos_accumulates_across_addresses
+    one = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
+    two = '1JSQBzkELK8UA9NVm4sZJ1CWGLEp8zUxR6'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{one}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"aa","confirmations":3}]}}')
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{two}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"bb","confirmations":4}]}}')
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[{"addresses":["#{one}"],"value":11,"script_hex":"00"}]}})
+      )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/bb?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[{"addresses":["#{two}"],"value":22,"script_hex":"01"}]}})
+      )
+    utxos = Sibit::Btc.new.utxos([one, two])
+    assert_equal(2, utxos.length)
+    assert_equal(%w[aa bb], utxos.map { |u| u[:hash] })
+    assert_equal([11, 22], utxos.map { |u| u[:value] })
+  end
+
+  def test_fetch_utxos_skips_outputs_for_other_address
+    addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
+    other = '1OtherAddrCCCCCCCCCCCCCCCCCCCCCCCC'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"aa","confirmations":1}]}}')
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[
+          {"addresses":["#{other}"],"value":99,"script_hex":"FF"},
+          {"addresses":["#{addr}"],"value":7,"script_hex":"00"}
+        ]}})
+      )
+    utxos = Sibit::Btc.new.utxos([addr])
+    assert_equal(1, utxos.length)
+    assert_equal(7, utxos[0][:value])
+    assert_equal(1, utxos[0][:index])
+  end
+
+  def test_fetch_utxos_raises_when_address_not_found
+    addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(body: '{"data":null}')
+    assert_raises(Sibit::Error) { Sibit::Btc.new.utxos([addr]) }
+  end
+
+  def test_fetch_utxos_returns_empty_when_list_is_nil
+    addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(body: '{"data":{}}')
+    utxos = Sibit::Btc.new.utxos([addr])
+    assert_equal([], utxos)
+  end
+
   def test_txns_raises_on_empty_list
     hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
     stub_request(:get, "https://chain.api.btc.com/v3/block/#{hash}")


### PR DESCRIPTION
Closes #245.

Sibit::Btc#utxos initialized a local `txns = []`, then overwrote it on every iteration with `data['list']` returned for the current address, so any UTXOs accumulated for prior addresses were dropped. Inside the same loop the method appended projected hashes back onto that array while it was being iterated, mixing raw API rows with projected hashes in the returned list. The fix introduces a separate `results` accumulator, keeps `data['list']` in its own local, and pushes the projected hash onto `results`; the input list is never mutated mid-iteration. The contract now matches `Sibit::Blockchain#utxos`, returning hashes with `value`, `hash`, `index`, `confirmations`, and `script`.

The five new unit tests in test/test_btc.rb cover the single-address happy path, accumulation across two addresses, filtering of outputs that belong to a different address, the address-not-found error path, and the nil-list path.

Ran `bundle exec ruby -Ilib -Itest test/test_btc.rb` (26 tests, 46 assertions, 0 failures, 0 errors, 0 skips) and `bundle exec rubocop` on the full tree (56 files, no offenses).
