### PR TITLE
fix: #254 register sochain and cryptoapis adapters in the CLI

### DIFF
--- a/bin/sibit
+++ b/bin/sibit
@@ -15,11 +15,13 @@ require_relative '../lib/sibit/blockchain'
 require_relative '../lib/sibit/blockchair'
 require_relative '../lib/sibit/btc'
 require_relative '../lib/sibit/cex'
+require_relative '../lib/sibit/cryptoapis'
 require_relative '../lib/sibit/dry'
 require_relative '../lib/sibit/fake'
 require_relative '../lib/sibit/firstof'
 require_relative '../lib/sibit/http'
 require_relative '../lib/sibit/httpproxy'
+require_relative '../lib/sibit/sochain'
 require_relative '../lib/sibit/version'
 
 begin

--- a/lib/sibit/bin.rb
+++ b/lib/sibit/bin.rb
@@ -160,6 +160,10 @@ class Sibit
             Sibit::Blockchair.new(http: http, log: log)
           when 'cex'
             Sibit::Cex.new(http: http, log: log)
+          when 'cryptoapis'
+            Sibit::Cryptoapis.new(ENV.fetch('SIBIT_CRYPTOAPIS_KEY', nil), http: http, log: log)
+          when 'sochain'
+            Sibit::Sochain.new(http: http, log: log)
           when 'fake'
             Sibit::Fake.new
           else

--- a/test/test_bin.rb
+++ b/test/test_bin.rb
@@ -13,11 +13,13 @@ require_relative '../lib/sibit/blockchain'
 require_relative '../lib/sibit/blockchair'
 require_relative '../lib/sibit/btc'
 require_relative '../lib/sibit/cex'
+require_relative '../lib/sibit/cryptoapis'
 require_relative '../lib/sibit/dry'
 require_relative '../lib/sibit/fake'
 require_relative '../lib/sibit/firstof'
 require_relative '../lib/sibit/http'
 require_relative '../lib/sibit/httpproxy'
+require_relative '../lib/sibit/sochain'
 require_relative 'test__helper'
 
 # Tests for the CLI.
@@ -95,5 +97,20 @@ class TestBin < Minitest::Test
 
   def test_generates_key_via_command_line
     assert_match(/^[0-9a-f]{64}$/, qbash('bin/sibit generate').strip, 'must print 64-char hex key')
+  end
+
+  def test_balance_via_sochain_api
+    addr = 'bc1qcj9pwdant20em83mvf9fzrc7ytm7szau5ysh9x'
+    stub = stub_request(:get, "https://sochain.com/api/v2/get_address_balance/BTC/#{addr}")
+      .to_return(body: '{"data":{"confirmed_balance":"0.0005"}}')
+    Sibit::Bin.start(['balance', addr, '--api', 'sochain', '--quiet'])
+    assert_requested(stub)
+  end
+
+  def test_latest_via_cryptoapis_api
+    stub = stub_request(:get, 'https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/latest')
+      .to_return(body: '{"payload":{"hash":"00000000abc123"}}')
+    Sibit::Bin.start(['latest', '--api', 'cryptoapis', '--quiet'])
+    assert_requested(stub)
   end
 end


### PR DESCRIPTION
The CLI's `--api` switch in `lib/sibit/bin.rb` did not recognise `sochain` or `cryptoapis`, and the `bin/sibit` executable did not load either adapter, so both providers were unreachable from the command line even though the classes ship in the gem.

`Sibit::Bin#client` now has dedicated `when 'sochain'` and `when 'cryptoapis'` branches that build the matching adapters, and `bin/sibit` requires both files. The `cryptoapis` branch reads the optional API key from the `SIBIT_CRYPTOAPIS_KEY` environment variable, mirroring how `SIBIT_PROXY` already flows into the proxy option, so the call works whether or not the user has a key.

Ran `bundle exec ruby -Ilib -Itest test/test_bin.rb`, which exercises the two new tests `test_balance_via_sochain_api` and `test_latest_via_cryptoapis_api` along with the existing CLI tests (5 tests, 6 assertions, 0 failures). Ran the full `rake test` task as well, which reports 238 tests / 347 assertions / 0 failures (the only errors are in `test_cross.rb`, which needs a running Docker daemon that is not available in this environment, and they reproduce on `master`). Ran `bundle exec rubocop bin/sibit lib/sibit/bin.rb test/test_bin.rb` and got `no offenses detected`.

Closes #254
