### PR TITLE
fix: #256 send blockchair api key as query parameter

### DIFF
--- a/lib/sibit/blockchair.rb
+++ b/lib/sibit/blockchair.rb
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require 'cgi'
 require 'iri'
 require 'json'
 require 'loog'
@@ -43,9 +42,9 @@ class Sibit::Blockchair
 
   # Gets the balance of the address, in satoshi.
   def balance(address)
-    json = Sibit::Json.new(http: @http, log: @log).get(
-      Iri.new('https://api.blockchair.com/bitcoin/dashboards/address').append(address).fragment(the_key)
-    )['data'][address]
+    uri = Iri.new('https://api.blockchair.com/bitcoin/dashboards/address').append(address)
+    uri = uri.add(key: @key) unless @key.nil?
+    json = Sibit::Json.new(http: @http, log: @log).get(uri)['data'][address]
     if json.nil?
       @log.debug("Address #{address} not found")
       return 0
@@ -72,21 +71,14 @@ class Sibit::Blockchair
 
   # Push this transaction (in hex format) to the network.
   def push(hex)
-    Sibit::Json.new(http: @http, log: @log).post(
-      Iri.new('https://api.blockchair.com/bitcoin/push/transaction').fragment(the_key),
-      "data=#{hex}"
-    )
+    uri = Iri.new('https://api.blockchair.com/bitcoin/push/transaction')
+    uri = uri.add(key: @key) unless @key.nil?
+    Sibit::Json.new(http: @http, log: @log).post(uri, "data=#{hex}")
     @log.debug("Transaction (#{hex.length} in hex) has been pushed to Blockchair")
   end
 
   # This method should fetch a Blockchain block and return as a hash.
   def block(_hash)
     raise(Sibit::NotSupportedError, 'Blockchair doesn\'t implement block()')
-  end
-
-  private
-
-  def the_key
-    @key.nil? ? '' : "key=#{CGI.escape(@key)}"
   end
 end

--- a/test/test_blockchair.rb
+++ b/test/test_blockchair.rb
@@ -77,7 +77,7 @@ class TestBlockchair < Minitest::Test
 
   def test_uses_api_key_in_requests
     hash = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
-    stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{hash}")
+    stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{hash}?key=testkey")
       .to_return(body: "{\"data\": {\"#{hash}\": {\"address\": {\"balance\": 100}}}}")
     assert_equal(
       100, Sibit::Blockchair.new(key: 'testkey').balance(hash),
@@ -86,8 +86,22 @@ class TestBlockchair < Minitest::Test
   end
 
   def test_push_with_api_key
-    stub_request(:post, 'https://api.blockchair.com/bitcoin/push/transaction')
+    stub_request(:post, 'https://api.blockchair.com/bitcoin/push/transaction?key=testkey')
       .to_return(body: '{"data": {"transaction_hash": "abc123"}}')
     Sibit::Blockchair.new(key: 'testkey').push('deadbeef')
+  end
+
+  def test_balance_url_omits_key_when_nil
+    hash = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
+    stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{hash}")
+      .to_return(body: "{\"data\": {\"#{hash}\": {\"address\": {\"balance\": 1}}}}")
+    assert_equal(1, Sibit::Blockchair.new.balance(hash))
+  end
+
+  def test_url_encodes_api_key
+    hash = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
+    stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{hash}?key=key%26evil")
+      .to_return(body: "{\"data\": {\"#{hash}\": {\"address\": {\"balance\": 5}}}}")
+    assert_equal(5, Sibit::Blockchair.new(key: 'key&evil').balance(hash))
   end
 end


### PR DESCRIPTION
The key argument on `Sibit::Blockchair` was appended via `Iri#fragment`, which produces a URL fragment that HTTP clients strip before sending; the helper `the_key` at `lib/sibit/blockchair.rb:89-91` plus the two call sites in `balance` and `push` meant any caller passing `key:` to lift Blockchair anonymous rate limits or use a paid plan was silently downgraded to unauthenticated calls. Closes #256.

The fix replaces `.fragment(the_key)` at both call sites with `Iri#add(key: @key)`, guarded by `unless @key.nil?` so the URL stays clean when no key is configured. `Iri#add` URL-encodes its values, so the previous `CGI.escape` is no longer needed and the `the_key` helper and the `require 'cgi'` were dropped.

Ran `bundle exec ruby -Ilib -Itest test/test_blockchair.rb` (14 tests, 12 assertions, 0 failures) and `bundle exec rake test` (238 tests, 0 failures; the 7 errors are the pre-existing Docker-based `test_cross.rb` cases that need a daemon this environment lacks). Ran `bundle exec rubocop` on the whole tree and got `no offenses detected`. Tightened the existing key-bearing stubs to assert on the query string and added `test_balance_url_omits_key_when_nil` and `test_url_encodes_api_key` to lock in both branches.