### PR TITLE
fix!: #260 pass body verbatim in Sibit::Json#post

### DIFF
--- a/lib/sibit/blockchain.rb
+++ b/lib/sibit/blockchain.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'cgi'
 require 'iri'
 require 'json'
 require 'loog'
@@ -100,7 +101,10 @@ class Sibit::Blockchain
 
   # Push this transaction (in hex format) to the network.
   def push(hex)
-    Sibit::Json.new(http: @http, log: @log).post(Iri.new('https://blockchain.info/pushtx'), hex)
+    Sibit::Json.new(http: @http, log: @log).post(
+      Iri.new('https://blockchain.info/pushtx'),
+      "tx=#{CGI.escape(hex)}"
+    )
   end
 
   # Gets the hash of the latest block.

--- a/lib/sibit/cryptoapis.rb
+++ b/lib/sibit/cryptoapis.rb
@@ -90,7 +90,7 @@ class Sibit::Cryptoapis
     Sibit::Json.new(http: @http, log: @log).post(
       Iri.new('https://api.cryptoapis.io/v1/bc/btc/mainnet/txs/send'),
       JSON.pretty_generate(hex: hex),
-      headers: headers
+      headers: headers.merge('Content-Type' => 'application/json')
     )
   end
 

--- a/lib/sibit/json.rb
+++ b/lib/sibit/json.rb
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require 'cgi'
 require 'elapsed'
 require 'json'
 require 'loog'
@@ -62,7 +61,7 @@ class Sibit::Json
     elapsed(@log) do
       res = @http.client(uri).post(
         "#{uri.path}?#{uri.query}",
-        "tx=#{CGI.escape(body)}",
+        body,
         {
           'Accept' => 'text/plain',
           'User-Agent' => user_agent,

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -37,4 +37,23 @@ class TestBlockchain < Minitest::Test
       .to_return(body: '{"next_block": ["nxt"]}')
     assert_equal('nxt', Sibit::Blockchain.new.next_of(hash))
   end
+
+  def test_push_wraps_hex_in_tx_param
+    stub = stub_request(:post, 'https://blockchain.info/pushtx')
+      .with(
+        headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
+        body: 'tx=deadbeef'
+      )
+      .to_return(body: '')
+    Sibit::Blockchain.new.push('deadbeef')
+    assert_requested(stub)
+  end
+
+  def test_push_url_escapes_hex_payload
+    stub = stub_request(:post, 'https://blockchain.info/pushtx')
+      .with(body: 'tx=a%26b')
+      .to_return(body: '')
+    Sibit::Blockchain.new.push('a&b')
+    assert_requested(stub)
+  end
 end

--- a/test/test_blockchair.rb
+++ b/test/test_blockchair.rb
@@ -71,6 +71,7 @@ class TestBlockchair < Minitest::Test
 
   def test_push_transaction
     stub_request(:post, 'https://api.blockchair.com/bitcoin/push/transaction')
+      .with(body: 'data=deadbeef')
       .to_return(body: '{"data": {"transaction_hash": "abc123"}}')
     Sibit::Blockchair.new.push('deadbeef')
   end

--- a/test/test_cryptoapis.rb
+++ b/test/test_cryptoapis.rb
@@ -80,6 +80,10 @@ class TestCryptoapis < Minitest::Test
 
   def test_push_transaction
     stub = stub_request(:post, 'https://api.cryptoapis.io/v1/bc/btc/mainnet/txs/send')
+      .with(
+        headers: { 'Content-Type' => 'application/json' },
+        body: JSON.pretty_generate(hex: 'deadbeef')
+      )
       .to_return(body: '{"payload": {"txid": "abc123"}}')
     Sibit::Cryptoapis.new('-').push('deadbeef')
     assert_requested(stub)

--- a/test/test_json.rb
+++ b/test/test_json.rb
@@ -20,4 +20,27 @@ class TestJson < Minitest::Test
     json = Sibit::Json.new.get(URI('https://hello.com/'))
     assert_equal(123, json['test'])
   end
+
+  def test_post_passes_body_verbatim
+    stub = stub_request(:post, 'https://hello.com/')
+      .with(body: 'raw=payload&x=1')
+      .to_return(body: 'ok')
+    Sibit::Json.new.post(URI('https://hello.com/'), 'raw=payload&x=1')
+    assert_requested(stub)
+  end
+
+  def test_post_honors_caller_content_type
+    stub = stub_request(:post, 'https://hello.com/')
+      .with(
+        headers: { 'Content-Type' => 'application/json' },
+        body: '{"k":"v"}'
+      )
+      .to_return(body: 'ok')
+    Sibit::Json.new.post(
+      URI('https://hello.com/'),
+      '{"k":"v"}',
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
Sibit::Json#post wrapped every body in tx=#{CGI.escape(body)} and pinned the Content-Type to application/x-www-form-urlencoded, so Blockchair and Cryptoapis pushes were re-encoded on top of their own format and the upstream endpoints rejected the transactions reported in #260.

Sibit::Json#post now passes the body through unchanged while keeping form-urlencoded as the default Content-Type, so the existing Blockchair call site keeps working and the Cryptoapis call site can override the header. Sibit::Blockchain#push now builds its own tx=<hex> body locally, Sibit::Cryptoapis#push sets Content-Type: application/json alongside the X-API-Key header, and Sibit::Blockchair#push keeps sending its data=<hex> payload unchanged. Callers of Sibit::Json#post must now shape the body themselves, which is the breaking change.

Ran `bundle exec rake test` on the patched tree: 244 tests, 353 assertions, 0 failures, 7 errors, 15 skips. The 7 errors are the pre-existing Docker-driven cross-platform tests in test/test_cross.rb that depend on a running Docker daemon and also error on master. Ran `bundle exec rubocop` over the four touched library and four touched test files: 7 files inspected, no offenses detected.

Closes #260