### PR TITLE
fix: #265 drop trailing `?` in Sibit::Json#post

### DIFF
--- a/lib/sibit/json.rb
+++ b/lib/sibit/json.rb
@@ -61,7 +61,7 @@ class Sibit::Json
     uri = URI(address.to_s)
     elapsed(@log) do
       res = @http.client(uri).post(
-        "#{uri.path}?#{uri.query}",
+        "#{uri.path.empty? ? '/' : uri.path}#{"?#{uri.query}" if uri.query}",
         "tx=#{CGI.escape(body)}",
         {
           'Accept' => 'text/plain',

--- a/test/test_json.rb
+++ b/test/test_json.rb
@@ -20,4 +20,27 @@ class TestJson < Minitest::Test
     json = Sibit::Json.new.get(URI('https://hello.com/'))
     assert_equal(123, json['test'])
   end
+
+  def test_post_drops_empty_query
+    captured = nil
+    fake_http = Class.new do
+      define_method(:client) do |_uri|
+        client = Object.new
+        client.define_singleton_method(:post) do |path, _body, _headers|
+          captured = path
+          Struct.new(:code, :body).new('200', '')
+        end
+        client
+      end
+    end.new
+    Sibit::Json.new(http: fake_http).post(URI('https://hello.com/pushtx'), 'deadbeef')
+    refute_match(/\?\z/, captured)
+    assert_equal('/pushtx', captured)
+  end
+
+  def test_post_keeps_query
+    stub = stub_request(:post, 'https://hello.com/pushtx?key=abc').to_return(body: '')
+    Sibit::Json.new.post(URI('https://hello.com/pushtx?key=abc'), 'deadbeef')
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
Sibit::Json#post builds its request line as `"#{uri.path}?#{uri.query}"`, with no guard for either an empty path or a missing query, so every push call carrying a query-less `Iri` posts a trailing `?` to the upstream service. The sibling `Sibit::Json#get` already uses `"#{uri.path.empty? ? '/' : uri.path}#{"?#{uri.query}" if uri.query}"`, which falls back to `/` for an empty path and only appends the `?` separator when `uri.query` is present. Per #265, several CDNs and WAFs treat a bare `?` as malformed and answer 400 before the request reaches the API.

This patch lifts the same template into `Sibit::Json#post` at `lib/sibit/json.rb:64`. `Sibit::Blockchain#push`, `Sibit::Sochain#push`, and the key-less branch of `Sibit::Blockchair#push` stop emitting a trailing `?`; query-bearing pushes such as `Sibit::Blockchair#push` with a `key` parameter keep their existing request line.

Ran `bundle exec rake test` on the patched tree: 242 tests, 353 assertions, 0 failures, 7 errors, 15 skips. The 7 errors are the pre-existing `test/test_cross.rb` Docker-driven cross-platform tests that also error on master. Ran `bundle exec rake rubocop`: 56 files inspected, no offenses detected. Added two `test/test_json.rb` cases (`test_post_drops_empty_query`, `test_post_keeps_query`) that capture the request path through an injected fake HTTP client and assert the `?` is dropped when no query is present and preserved when one is.

Closes #265
