### PR TITLE
fix: #268 raise Sibit::Error when blockchain.info omits height

### DIFF
--- a/lib/sibit/blockchain.rb
+++ b/lib/sibit/blockchain.rb
@@ -48,6 +48,7 @@ class Sibit::Blockchain
     h = Sibit::Json.new(http: @http, log: @log).get(
       Iri.new('https://blockchain.info/rawblock').append(hash)
     )['height']
+    raise(Sibit::Error, "The block #{hash} found but the height is absent") if h.nil?
     @log.debug("The height of #{hash} is #{h}")
     h
   end

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -37,4 +37,19 @@ class TestBlockchain < Minitest::Test
       .to_return(body: '{"next_block": ["nxt"]}')
     assert_equal('nxt', Sibit::Blockchain.new.next_of(hash))
   end
+
+  def test_height
+    hash = '0000000000000000000f676241aabc9b62b748d26192a44bc25720c34de27d19'
+    stub_request(:get, "https://blockchain.info/rawblock/#{hash}")
+      .to_return(body: '{"height": 600000}')
+    assert_equal(600_000, Sibit::Blockchain.new.height(hash))
+  end
+
+  def test_height_raises_when_absent
+    hash = '0000000000000000000f676241aabc9b62b748d26192a44bc25720c34de27d19'
+    stub_request(:get, "https://blockchain.info/rawblock/#{hash}").to_return(body: '{}')
+    assert_raises(Sibit::Error) do
+      Sibit::Blockchain.new.height(hash)
+    end
+  end
 end


### PR DESCRIPTION
Closes #268.

Sibit::Blockchain#height returned nil silently when the rawblock response lacked the 'height' field, while sibling adapters Sibit::Btc#height (lib/sibit/btc.rb:70-79) and Sibit::Sochain#height (lib/sibit/sochain.rb:46-55) raise Sibit::Error in the same case. The silent nil was invisible to Sibit::FirstOf and Sibit::BestOf, which only fall back on Sibit::Error and Sibit::NotSupportedError; downstream Integer(h) or arithmetic on the result crashed later with a less informative TypeError.

The fix is one guard line in lib/sibit/blockchain.rb that mirrors the sibling adapters' message exactly. Two new tests in test/test_blockchain.rb pin the contract: a happy path with a stubbed 'height': 600000 body, and an absent-height case asserting Sibit::Error.

Ran bundle exec ruby -e "require 'rake'; Rake.load_rakefile('Rakefile'); Rake::Task['test'].invoke" on this branch: 244 tests, 355 assertions, 0 failures, 7 errors, 15 skips. The seven errors come from the test_works_on_* cross-platform suite (Docker-driven) and were already failing on master (242 tests, 7 errors) so they predate this change. Rubocop on the two modified files is clean.

---
_Generated by [Claude Code](https://claude.ai/code)_