### PR TITLE
#264: Raise Sibit error for unknown currency

### DIFF
--- a/lib/sibit/blockchain.rb
+++ b/lib/sibit/blockchain.rb
@@ -32,7 +32,7 @@ class Sibit::Blockchain
     h = Sibit::Json.new(http: @http, log: @log).get(
       Iri.new('https://blockchain.info/ticker')
     )[currency]
-    raise(Error, "Unrecognized currency #{currency}") if h.nil?
+    raise(Sibit::Error, "Unrecognized currency #{currency}") if h.nil?
     price = h['15m']
     @log.debug("The price of BTC is #{price} USD")
     price

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -30,6 +30,11 @@ class TestBlockchain < Minitest::Test
     assert_kind_of(Array, json[:txns][0][:outputs])
   end
 
+  def test_rejects_unknown_currency
+    stub_request(:get, 'https://blockchain.info/ticker').to_return(body: '{}')
+    assert_raises(Sibit::Error) { Sibit::Blockchain.new.price('XYZ') }
+  end
+
   def test_next_of
     skip('does not work')
     hash = '0000000000000000000f676241aabc9b62b748d26192a44bc25720c34de27d19'


### PR DESCRIPTION
`Sibit::Blockchain#price` now raises `Sibit::Error` when the requested currency is absent from the ticker response. This keeps adapter failures recoverable by `Sibit::FirstOf` and `Sibit::BestOf` instead of leaking a `NameError`.

The regression test stubs an empty ticker response and verifies the public exception type.

Closes #264

## Testing

- `bundle exec rake` — passed locally: 243 tests, 354 assertions, 0 failures/errors; Cucumber and RuboCop passed
- Public adapter smoke returned `Sibit::Error: Unrecognized currency XYZ`

The current GitHub Actions rake run reaches and passes the new regression, then fails six existing `TestRegtest` cases because the pulled Bitcoin Core container reports `Requested wallet does not exist or is not loaded`. The failure is outside the changed adapter and test.