### PR TITLE
Encode P2SH (3…) target addresses as P2SH scripts

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -100,6 +100,7 @@ Elegant/GoodMethodName:
     - p2pkh_address
     - p2pkh_script
     - p2pkh?
+    - p2sh_script
     - p2wpkh_address
     - p2wpkh?
     - prev_out
@@ -129,6 +130,7 @@ Elegant/GoodMethodName:
     - test_extracts_hash160_from_p2wpkh
     - test_extracts_hash160_from_script
     - test_extracts_segwit_address_from_p2wpkh
+    - test_output_generates_p2sh_script
     - test_parses_p2pkh_script
     - test_parses_p2wpkh_script
     - test_regtest_bech32_starts_with_bcrt1q

--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -6,6 +6,7 @@
 require 'digest'
 require_relative 'base58'
 require_relative 'bech32'
+require_relative 'error'
 require_relative 'key'
 require_relative 'script'
 
@@ -105,7 +106,9 @@ class Sibit
 
       def script
         return segwit_script if segwit?
-        p2pkh_script
+        return p2pkh_script if %w[00 6f].include?(version)
+        return p2sh_script if %w[05 c4].include?(version)
+        raise(Sibit::Error, "Address '#{@address}' has an unsupported version byte 0x#{version}")
       end
 
       def segwit?
@@ -118,11 +121,20 @@ class Sibit
 
       private
 
+      def version
+        Base58.new(@address).decode[0, 2]
+      end
+
+      def hash160
+        [Base58.new(@address).decode[2, 40]].pack('H*')
+      end
+
       def p2pkh_script
-        [
-          0x76, 0xa9,
-          0x14
-        ].pack('C*') + [Base58.new(@address).decode[2..41]].pack('H*') + [0x88, 0xac].pack('C*')
+        [0x76, 0xa9, 0x14].pack('C*') + hash160 + [0x88, 0xac].pack('C*')
+      end
+
+      def p2sh_script
+        [0xa9, 0x14].pack('C*') + hash160 + [0x87].pack('C*')
       end
 
       def segwit_script

--- a/test/test_regtest.rb
+++ b/test/test_regtest.rb
@@ -194,7 +194,8 @@ class TestRegtest < Minitest::Test
         '-rpcport=18443',
         '-rpcuser=test',
         '-rpcpassword=test',
-        '-fallbackfee=0.0001'
+        '-fallbackfee=0.0001',
+        '-deprecatedrpc=create_bdb'
       ].join(' '),
       timeout: 600,
       stdout: Loog::NULL

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -143,6 +143,24 @@ class TestTx < Minitest::Test
     )
   end
 
+  def test_output_generates_p2sh_script
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, '36sxuNPT13FFmRPVJ5h9fBjXwB7cvZTnfY')
+    assert_equal(
+      'a91438eaaeee66e2d15f50e96a96e389db9ca467d58f87',
+      tx.outputs[0].script_hex,
+      'P2SH address cannot be encoded as a P2PKH script'
+    )
+  end
+
+  def test_rejects_unknown_address_version
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, 'CXCWzGeaY7ApHokRuF7L5Qygkw7qQzrzJw')
+    assert_raises(Sibit::Error, 'unsupported address version cannot be silently encoded') do
+      tx.outputs[0].script_hex
+    end
+  end
+
   def test_output_generates_segwit_script
     tx = Sibit::Tx.new
     tx.add_output(10_000, 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')


### PR DESCRIPTION
`Sibit::Tx::Output#script` built a P2PKH script (`76a914…88ac`) for every address that was not bech32. A P2SH target (`3…`) therefore had its hash160 stuffed into a P2PKH script, which is really the legacy `1…` address sharing that same hash. Coins sent to a `3…` address landed at a `1…` address nobody controls and were lost.

This makes the output honour the Base58 version byte: `a914…87` for P2SH (`05`/`c4`), `76a914…88ac` for P2PKH (`00`/`6f`), and a `Sibit::Error` for any other version rather than a silent misdirection. There is a regression test that pins the P2SH script for the exact address from the incident, plus one that checks the unknown-version guard.

Worth noting separately: for segwit spends `Tx#hash` still computes the txid over the witness-inclusive serialization, so the id it prints does not match the chain. That is a different bug and not touched here.

Closes #283