### PR TITLE
Send POST body verbatim instead of always wrapping it in tx=

### DIFF
--- a/lib/sibit/blockchain.rb
+++ b/lib/sibit/blockchain.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require 'cgi'
 require 'iri'
 require 'json'
 require 'loog'
@@ -100,7 +101,9 @@ class Sibit::Blockchain
 
   # Push this transaction (in hex format) to the network.
   def push(hex)
-    Sibit::Json.new(http: @http, log: @log).post(Iri.new('https://blockchain.info/pushtx'), hex)
+    Sibit::Json.new(http: @http, log: @log).post(
+      Iri.new('https://blockchain.info/pushtx'), "tx=#{CGI.escape(hex)}"
+    )
   end
 
   # Gets the hash of the latest block.

--- a/lib/sibit/cryptoapis.rb
+++ b/lib/sibit/cryptoapis.rb
@@ -90,7 +90,7 @@ class Sibit::Cryptoapis
     Sibit::Json.new(http: @http, log: @log).post(
       Iri.new('https://api.cryptoapis.io/v1/bc/btc/mainnet/txs/send'),
       JSON.pretty_generate(hex: hex),
-      headers: headers
+      headers: headers.merge('Content-Type' => 'application/json')
     )
   end
 

--- a/lib/sibit/json.rb
+++ b/lib/sibit/json.rb
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
-require 'cgi'
 require 'elapsed'
 require 'json'
 require 'loog'
@@ -62,7 +61,7 @@ class Sibit::Json
     elapsed(@log) do
       res = @http.client(uri).post(
         "#{uri.path.empty? ? '/' : uri.path}#{"?#{uri.query}" if uri.query}",
-        "tx=#{CGI.escape(body)}",
+        body,
         {
           'Accept' => 'text/plain',
           'User-Agent' => user_agent,

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -37,4 +37,12 @@ class TestBlockchain < Minitest::Test
       .to_return(body: '{"next_block": ["nxt"]}')
     assert_equal('nxt', Sibit::Blockchain.new.next_of(hash))
   end
+
+  def test_push_wraps_body_in_tx_form
+    stub = stub_request(:post, 'https://blockchain.info/pushtx')
+      .with(body: 'tx=deadbeef', headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
+      .to_return(body: '')
+    Sibit::Blockchain.new.push('deadbeef')
+    assert_requested(stub, times: 1)
+  end
 end

--- a/test/test_blockchair.rb
+++ b/test/test_blockchair.rb
@@ -75,6 +75,14 @@ class TestBlockchair < Minitest::Test
     Sibit::Blockchair.new.push('deadbeef')
   end
 
+  def test_push_sends_body_verbatim
+    stub = stub_request(:post, 'https://api.blockchair.com/bitcoin/push/transaction')
+      .with(body: 'data=deadbeef')
+      .to_return(body: '{"data": {"transaction_hash": "abc123"}}')
+    Sibit::Blockchair.new.push('deadbeef')
+    assert_requested(stub, times: 1)
+  end
+
   def test_uses_api_key_in_requests
     hash = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
     stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{hash}?key=testkey")

--- a/test/test_cryptoapis.rb
+++ b/test/test_cryptoapis.rb
@@ -85,6 +85,17 @@ class TestCryptoapis < Minitest::Test
     assert_requested(stub)
   end
 
+  def test_push_sends_json_verbatim
+    stub = stub_request(:post, 'https://api.cryptoapis.io/v1/bc/btc/mainnet/txs/send')
+      .with(
+        body: JSON.pretty_generate(hex: 'deadbeef'),
+        headers: { 'Content-Type' => 'application/json' }
+      )
+      .to_return(body: '{"payload": {"txid": "abc123"}}')
+    Sibit::Cryptoapis.new('-').push('deadbeef')
+    assert_requested(stub, times: 1)
+  end
+
   def test_works_without_api_key
     hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
     stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")


### PR DESCRIPTION
`Sibit::Json#post` used to wrap every body in `tx=<escaped>` and pin the content type to `application/x-www-form-urlencoded`. That shape only fits the Blockchain.com `pushtx` endpoint. Now the body passes through untouched, the content type defaults to form-urlencoded only when the caller does not set its own, and each provider builds the body and headers it actually needs.

This matters because Blockchair handed in a pre-formed `data=<hex>` body and Cryptoapis handed in a JSON document with an `X-API-Key` header. Both got re-encoded on top of their own format, so Blockchair saw no `data=` parameter and Cryptoapis received a form-encoded JSON string, and both rejected the transaction. Blockchain.com now forms its own `tx=<hex>` body at the call site, Blockchair sends its bytes as-is, and Cryptoapis sends real JSON with the right content type.

Added tests for all three providers that assert the exact body and headers on the wire.

Closes #260