### PR TITLE
Forward SIBIT_BLOCKCHAIR_KEY env var to the Blockchair adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ The proxy address may include authentication credentials:
 sibit --proxy=user:password@host:port balance 1PfsYNygsuVL8fvBarJNQnHytkg4rGih1U
 ```
 
+Some providers accept an API key, read from an environment variable:
+`SIBIT_BLOCKCHAIR_KEY` for [Blockchair.com] and
+  `SIBIT_CRYPTOAPIS_KEY` for [Cryptoapis.io].
+When the variable is set, requests to that provider use the authenticated tier.
+
 All operations are performed through the [Blockchain API].
 Transactions are pushed to the Bitcoin network via [this relay].
 

--- a/lib/sibit/bin.rb
+++ b/lib/sibit/bin.rb
@@ -157,7 +157,7 @@ class Sibit
           when 'bitcoinchain'
             Sibit::Bitcoinchain.new(http: http, log: log)
           when 'blockchair'
-            Sibit::Blockchair.new(http: http, log: log)
+            Sibit::Blockchair.new(key: ENV.fetch('SIBIT_BLOCKCHAIR_KEY', nil), http: http, log: log)
           when 'cex'
             Sibit::Cex.new(http: http, log: log)
           when 'cryptoapis'

--- a/test/test_bin.rb
+++ b/test/test_bin.rb
@@ -113,4 +113,17 @@ class TestBin < Minitest::Test
     Sibit::Bin.start(['latest', '--api', 'cryptoapis', '--quiet'])
     assert_requested(stub)
   end
+
+  def test_blockchair_balance_uses_env_key
+    addr = '1GkQmKAmHtNfnD3LHhTkewJxKHVSta4m2a'
+    stub = stub_request(:get, "https://api.blockchair.com/bitcoin/dashboards/address/#{addr}?key=envkey")
+      .to_return(body: "{\"data\": {\"#{addr}\": {\"address\": {\"balance\": 7}}}}")
+    ENV['SIBIT_BLOCKCHAIR_KEY'] = 'envkey'
+    begin
+      Sibit::Bin.start(['balance', addr, '--api', 'blockchair', '--quiet'])
+    ensure
+      ENV.delete('SIBIT_BLOCKCHAIR_KEY')
+    end
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
The CLI built the Blockchair adapter with `Sibit::Blockchair.new(http:, log:)` and never read a key from anywhere. Since the adapter appends `key:` to the upstream URL when it is set, a user running `sibit --api=blockchair ...` against an authenticated endpoint could only hit the unauthenticated tier and its lower rate limit.

This reads the key from a new `SIBIT_BLOCKCHAIR_KEY` environment variable and forwards it, mirroring how `SIBIT_CRYPTOAPIS_KEY` is already wired for Cryptoapis. The README now documents both variables next to the proxy notes.

Added a CLI test that sets the env var and checks the outgoing Blockchair request carries `?key=`.

Closes #267