### PR TITLE
Pin the regtest bitcoind image to an explicit v28 tag

### DIFF
--- a/test/test_regtest.rb
+++ b/test/test_regtest.rb
@@ -184,7 +184,7 @@ class TestRegtest < Minitest::Test
     WebMock.allow_net_connect!
     port = random_port
     donce(
-      image: 'ruimarinho/bitcoin-core:latest',
+      image: 'ruimarinho/bitcoin-core:28',
       ports: { port => 18_443 },
       root: true,
       command: [


### PR DESCRIPTION
The regtest suite pulled `ruimarinho/bitcoin-core:latest`, so the bitcoind image could advance with no change to this repo. That already bit us once: when `:latest` reached v28 it turned legacy `createwallet` off by default and every regtest errored with wallet code -18. This pins the tag to `:28`, which still honors the `-deprecatedrpc=create_bdb` flag the suite relies on, so the version is deterministic and any bump is a deliberate, reviewable change.

This deliberately does not touch the deeper problem: the suite still calls the legacy-only RPCs `dumpprivkey` and `importaddress`, which keep it below Bitcoin Core v29 (v29 drops BDB wallets entirely). I'll file a separate follow-up issue to derive the key locally and watch addresses via descriptor imports, so the `create_bdb` flag can go away and the tag can float forward again.

Closes #285