### PR TITLE
Reverse the txid by bytes instead of by nibbles in Tx#hash

### DIFF
--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -38,7 +38,7 @@ class Sibit
     end
 
     def hash
-      Digest::SHA256.hexdigest(Digest::SHA256.digest(payload)).reverse.scan(/../).join
+      Digest::SHA256.hexdigest(Digest::SHA256.digest(payload)).scan(/../).reverse.join
     end
 
     def payload

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -57,7 +57,7 @@ class TestBlockchain < Minitest::Test
       Sibit::Blockchain.new.height(hash)
     end
   end
-  
+
   def test_push_wraps_body_in_tx_form
     stub = stub_request(:post, 'https://blockchain.info/pushtx')
       .with(body: 'tx=deadbeef', headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -69,6 +69,16 @@ class TestTx < Minitest::Test
     assert_equal(2, tx.inputs[0].prev_out_index, 'input index does not match')
   end
 
+  def test_hash_reverses_txid_bytes_not_nibbles
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_equal(
+      'a6188127f7d857b46b8ba2e88f6f62a7f62dd5c700d1751486079f26bbfe7095',
+      tx.hash,
+      'txid must be the byte-reversed double-SHA256, not a nibble reversal'
+    )
+  end
+
   def test_generates_transaction_hash
     tx = Sibit::Tx.new
     tx.add_input(


### PR DESCRIPTION
`Tx#hash` computed the txid with `String#reverse` on the hex digest. That flips individual hex characters (nibbles), not the byte order a Bitcoin txid actually needs, and the trailing `.scan(/../).join` was then a no-op. So every txid the method returned was wrong (only a palindromic digest would survive, which never happens).

That value is what `Sibit#pay` hands back as the transaction hash, so callers recorded a txid that never appears on-chain or in any explorer. Since the docs say it is safe to retry, a caller who cannot find its txid would resend and pay twice. The fix reverses the byte pairs instead: `.scan(/../).reverse.join`.

The regression test asserts the exact txid of a deterministic (no-input) transaction, which pins the byte order down. A fully-signed vector cannot be pinned yet because inputs are re-signed with a random nonce on every call — that non-determinism is issue #287, and SegWit txid vs wtxid is #288; both are handled separately.

Closes #286