### PR TITLE
Sign the transaction payload once instead of on every call

### DIFF
--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -42,8 +42,9 @@ class Sibit
     end
 
     def payload
+      return @payload if @payload
       sign_inputs
-      serialize
+      @payload = serialize
     end
 
     def hex

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -79,6 +79,30 @@ class TestTx < Minitest::Test
     )
   end
 
+  def test_payload_stays_stable_across_calls
+    tx = Sibit::Tx.new
+    tx.add_input(
+      hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+      index: 0,
+      script: '76a914c14b1e5c95a4687da3f7c932bf39a3a89bdb3fa988ac',
+      key: Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
+    )
+    tx.add_output(10_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_equal(tx.payload, tx.payload, 'payload must be signed once, not re-signed per call')
+  end
+
+  def test_hash_stays_stable_across_calls
+    tx = Sibit::Tx.new
+    tx.add_input(
+      hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+      index: 0,
+      script: '76a914c14b1e5c95a4687da3f7c932bf39a3a89bdb3fa988ac',
+      key: Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
+    )
+    tx.add_output(10_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_equal(tx.hash, tx.hash, 'txid must identify one transaction, not change on every call')
+  end
+
   def test_generates_transaction_hash
     tx = Sibit::Tx.new
     tx.add_input(


### PR DESCRIPTION
Tx#payload signed all of the inputs each time it was called. Since ECDSA signing draws a fresh random nonce every time, each call produced different signature bytes, a different serialization, and therefore a different txid. This memoizes the signed bytes so hash, hex, and payload all describe the same transaction.

It matters because pay() materializes the transaction three times: once to log the txid, once to build the payload it broadcasts, and once to return the txid to the caller. The broadcast bytes and the returned id came from separate signing rounds, so the caller was handed an id for a transaction that never went out.

I added two regression tests that call payload and hash twice on the same object and expect identical results. Pairs with the byte-order fix in #286.

Closes #287