### PR TITLE
Return the txid, not the wtxid, for SegWit transactions

### DIFF
--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -38,7 +38,10 @@ class Sibit
     end
 
     def hash
-      Digest::SHA256.hexdigest(Digest::SHA256.digest(payload)).scan(/../).reverse.join
+      sign_inputs
+      Digest::SHA256.hexdigest(
+        Digest::SHA256.digest(serialize(witness: false))
+      ).scan(/../).reverse.join
     end
 
     def payload
@@ -151,6 +154,7 @@ class Sibit
     end
 
     def sign_inputs
+      return if @signed
       @inputs.each_with_index do |input, idx|
         sig = sign(input.key, (input.segwit? ? segwit_sighash(idx) : legacy_sighash(idx)))
         pubkey = [input.key.pub].pack('H*')
@@ -160,6 +164,7 @@ class Sibit
           input.script_sig = der_sig(sig) + pubkey_script(pubkey)
         end
       end
+      @signed = true
     end
 
     def legacy_sighash(idx)
@@ -245,9 +250,9 @@ class Sibit
       [pubkey.length].pack('C') + pubkey
     end
 
-    def serialize
+    def serialize(witness: witness?)
       result = [VERSION].pack('V')
-      result += [0x00, 0x01].pack('CC') if witness?
+      result += [0x00, 0x01].pack('CC') if witness
       result += varint(@inputs.length)
       @inputs.each do |input|
         result += [input.hash].pack('H*').reverse
@@ -263,7 +268,7 @@ class Sibit
         result += varint(script.length)
         result += script
       end
-      result += serialize_witness if witness?
+      result += serialize_witness if witness
       result += [0].pack('V')
       result
     end

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -103,6 +103,22 @@ class TestTx < Minitest::Test
     assert_equal(tx.hash, tx.hash, 'txid must identify one transaction, not change on every call')
   end
 
+  def test_hash_excludes_witness_for_segwit
+    tx = Sibit::Tx.new
+    tx.add_input(
+      hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+      index: 0,
+      script: '0014c14b1e5c95a4687da3f7c932bf39a3a89bdb3fa9',
+      key: Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
+    )
+    tx.add_output(10_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_equal(
+      'bc8d1f3c1aed799c25168d7c1fa75b435cf5f22a7349641734a6f2bbe8564dd7',
+      tx.hash,
+      'segwit txid must be the legacy-form hash, not the wtxid'
+    )
+  end
+
   def test_generates_transaction_hash
     tx = Sibit::Tx.new
     tx.add_input(


### PR DESCRIPTION
Tx#hash double-SHA256ed the whole payload. For a SegWit spend that payload carries the marker, flag, and witness section, so the result was the wtxid rather than the txid that nodes and explorers use to index a transaction. Since create() hands out bech32 P2WPKH addresses and pay() defaults to spending them, almost every payment hit this path and returned an id that can never be found on-chain.

Now hash serializes the transaction in legacy form — version, inputs, outputs, locktime, no marker/flag/witness — while payload and hex keep the full witness form for broadcast. A P2WPKH input has an empty script_sig, so the txid is stable even though the signature (which lives in the witness) uses a random nonce. Signing is also guarded to run once, so hash and payload always describe the same signed transaction.

The regression test asserts a known SegWit txid computed independently. Pairs with #286 (byte order) and #287 (sign once); all three concern the same money-critical value.

Closes #288