### PR TITLE
Validate the Base58 checksum of target and change addresses

### DIFF
--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -125,12 +125,24 @@ class Sibit
 
       private
 
+      def decoded
+        return @decoded if @decoded
+        hex = Base58.new(@address).decode
+        unless hex.length == 50
+          raise(Sibit::Error, "Address '#{@address}' does not decode to 25 bytes")
+        end
+        unless hex[-8..] == Base58.new(hex[0..-9]).check
+          raise(Sibit::Error, "Address '#{@address}' fails its Base58 checksum")
+        end
+        @decoded = hex
+      end
+
       def version
-        Base58.new(@address).decode[0, 2]
+        decoded[0, 2]
       end
 
       def hash160
-        [Base58.new(@address).decode[2, 40]].pack('H*')
+        [decoded[2, 40]].pack('H*')
       end
 
       def p2pkh_script

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -211,6 +211,22 @@ class TestTx < Minitest::Test
     end
   end
 
+  def test_rejects_target_with_broken_checksum
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, '1KvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_raises(Sibit::Error, 'a mistyped Base58 address cannot be silently accepted') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_target_that_decodes_too_short
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, '1A')
+    assert_raises(Sibit::Error, 'a truncated Base58 address cannot build a valid script') do
+      tx.outputs[0].script_hex
+    end
+  end
+
   def test_output_generates_segwit_script
     tx = Sibit::Tx.new
     tx.add_output(10_000, 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')


### PR DESCRIPTION
Tx::Output built an output script from any string made of Base58 characters, without checking the four-byte checksum or the 25-byte length that base58check addresses carry. A single mistyped, transposed, or truncated character still decoded, so pay() signed and broadcast a transaction paying a garbage hash160 — the coins gone for good.

The fix decodes the address once, requires exactly 25 bytes, and verifies the checksum the same way Key#decode already does for WIF keys, raising a Sibit::Error that names the offending address. Valid addresses are unaffected.

Two regression tests cover it: a valid address with one character changed, and an address too short to decode to 25 bytes. Both now raise.

I left the optional network-vs-version cross-check (mainnet coins to a testnet address) out of this change, since Output does not know the signing network; happy to file a follow-up for it if you want it. The bech32 output path is tracked separately in #290.

Closes #289