### PR TITLE
Honor the witness version when building Bech32 output scripts

### DIFF
--- a/lib/sibit/bech32.rb
+++ b/lib/sibit/bech32.rb
@@ -66,8 +66,19 @@ class Sibit
 
     def witness
       hrp, data = parse
+      ver = data[0]
+      unless ver.between?(0, 16)
+        raise(Sibit::Error, "Unsupported witness version #{ver} in '#{@addr}'")
+      end
       raise(Sibit::Error, "Invalid Bech32 checksum in '#{@addr}'") unless verified?(hrp, data)
-      convert(data[1..-7], 5, 8, false).pack('C*').unpack1('H*')
+      prog = convert(data[1..-7], 5, 8)
+      if ver.zero? && [20, 32].none?(prog.length)
+        raise(Sibit::Error, "Witness v0 program in '#{@addr}' must be 20 or 32 bytes")
+      end
+      unless prog.length.between?(2, 40)
+        raise(Sibit::Error, "Witness program in '#{@addr}' must be 2 to 40 bytes")
+      end
+      prog.pack('C*').unpack1('H*')
     end
 
     def version
@@ -88,7 +99,7 @@ class Sibit
     end
 
     def verified?(hrp, data)
-      [1, 0x2bc830a3].include?(polymod(expand(hrp) + data))
+      polymod(expand(hrp) + data) == (data[0].zero? ? 1 : 0x2bc830a3)
     end
 
     def expand(hrp)
@@ -105,7 +116,7 @@ class Sibit
       chk
     end
 
-    def convert(data, frombits, tobits, pad)
+    def convert(data, frombits, tobits)
       acc = 0
       bits = 0
       result = []
@@ -118,7 +129,9 @@ class Sibit
           result << ((acc >> bits) & maxv)
         end
       end
-      result << ((acc << (tobits - bits)) & maxv) if pad && bits.positive?
+      if bits >= frombits || (acc << (tobits - bits)).anybits?(maxv)
+        raise(Sibit::Error, "Non-zero padding in Bech32 address '#{@addr}'")
+      end
       result
     end
   end

--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -154,8 +154,13 @@ class Sibit
       end
 
       def segwit_script
-        witness = Bech32.new(@address).witness
-        [0x00, (witness.length / 2)].pack('C*') + [witness].pack('H*')
+        bech = Bech32.new(@address)
+        program = bech.witness
+        [opcode(bech.version), program.length / 2].pack('C*') + [program].pack('H*')
+      end
+
+      def opcode(version)
+        version.zero? ? 0x00 : 0x50 + version
       end
     end
 

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -236,6 +236,32 @@ class TestTx < Minitest::Test
     )
   end
 
+  def test_encodes_taproot_as_higher_witness
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, 'bc1pqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sg5tmnz')
+    assert_equal(
+      '5120000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+      tx.outputs[0].script_hex,
+      'taproot address must encode as witness v1, not v0'
+    )
+  end
+
+  def test_rejects_wrong_checksum_variant
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, 'bc1qqqqsyqcyq5rqwzqfpg9scrgwpugpzysnqslask')
+    assert_raises(Sibit::Error, 'a v0 address with a bech32m checksum cannot be accepted') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_witness_program_wrong_length
+    tx = Sibit::Tx.new
+    tx.add_output(10_000, 'bc1qqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarcgj48wy')
+    assert_raises(Sibit::Error, 'a 31-byte witness v0 program cannot build a valid script') do
+      tx.outputs[0].script_hex
+    end
+  end
+
   def test_output_segwit_script_has_correct_length
     tx = Sibit::Tx.new
     tx.add_output(10_000, 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')


### PR DESCRIPTION
segwit_script hardcoded OP_0 and pushed whatever program the address decoded to. A Taproot address (bc1p, witness v1) sailed through and became OP_0 <32 bytes> — a P2WSH output whose script preimage nobody knows. The transaction relays and confirms, and the coins are gone. Since Taproot receiving addresses are common now, this was an easy way to burn a payment with no error at all.

Now the real witness version is encoded (OP_n = 0x50 + n for n >= 1), so v1 produces 5120…. Bech32 also got the two validations BIP-350/173 require and that were missing: the checksum variant is tied to the version (bech32 for v0, bech32m for v1+), the program length is checked (20 or 32 bytes for v0, 2–40 otherwise), and non-zero padding bits are rejected instead of silently dropped.

Three regression tests, with vectors generated from the BIP-350 reference implementation: a Taproot address must encode as 5120…, a v0 address carrying a bech32m checksum must raise, and a v0 address with a 31-byte program must raise. The existing P2WPKH path is unchanged.

Closes #290