### PR TITLE
Fail fast on negative or dust change in payments

### DIFF
--- a/lib/sibit.rb
+++ b/lib/sibit.rb
@@ -19,7 +19,7 @@ require_relative 'sibit/version'
 # Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
 # License:: MIT
 class Sibit
-  MIN_SATOSHI_PER_BYTE = 0.1
+  MIN_SATOSHI_PER_BYTE = 1
 
   # Constructor.
   #

--- a/lib/sibit/bin.rb
+++ b/lib/sibit/bin.rb
@@ -101,7 +101,8 @@ class Sibit
       desc: 'Minimum number of confirmations required on a UTXO before it can be spent'
     def pay(amount, fee, sources, target, change)
       keys = sources.split(',')
-      if amount.upcase == 'MAX'
+      sweep = amount.upcase == 'MAX'
+      if sweep
         addrs =
           keys.map do |k|
             kk = Sibit::Key.new(k)
@@ -111,6 +112,7 @@ class Sibit
       end
       amount = Integer(amount, 10) if amount.is_a?(String) && /^[0-9]+$/.match?(amount)
       fee = Integer(fee, 10) if /^[0-9]+$/.match?(fee)
+      amount -= fee if sweep && fee.is_a?(Integer)
       args = [amount, fee, keys, target, change]
       kwargs = {
         skip_utxo: options[:skip_utxo], base58: options[:base58],

--- a/lib/sibit/blockchain.rb
+++ b/lib/sibit/blockchain.rb
@@ -77,7 +77,7 @@ class Sibit::Blockchain
       ].join
     )
     {
-      S: json['regular'] / 3,
+      S: (json['regular'] / 3.0).ceil,
       M: json['regular'],
       L: json['priority'],
       XL: json['limits']['max']

--- a/lib/sibit/txbuilder.rb
+++ b/lib/sibit/txbuilder.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
 # SPDX-License-Identifier: MIT
 
+require_relative 'error'
 require_relative 'key'
 require_relative 'tx'
 
@@ -17,6 +18,8 @@ class Sibit
   # Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
   # License:: MIT
   class TxBuilder
+    DUST = 546
+
     def initialize
       @inputs = []
       @outputs = []
@@ -47,6 +50,15 @@ class Sibit
       @outputs.each { |o| txn.add_output(o[:value], o[:address]) }
       if leave_fee
         change = input_value - total - extra_fee
+        if change.negative?
+          raise(
+            Sibit::Error,
+            "The inputs of #{input_value} cannot cover outputs of #{total} plus fee of #{extra_fee}"
+          )
+        end
+        if change.positive? && change < DUST
+          raise(Sibit::Error, "The change of #{change} is below the dust limit of #{DUST}")
+        end
         txn.add_output(change, change_address) if change.positive?
       end
       Built.new(txn, @inputs, @outputs)

--- a/test/test_bin.rb
+++ b/test/test_bin.rb
@@ -50,7 +50,7 @@ class TestBin < Minitest::Test
     stub_request(:post, 'https://blockchain.info/pushtx').to_return(status: 200)
     Sibit::Bin.start(
       [
-        'pay', 'MAX', '100',
+        'pay', 'MAX', '1000',
         'fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2',
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', '--yes', '--quiet'
@@ -86,7 +86,7 @@ class TestBin < Minitest::Test
     stub_request(:post, 'https://blockchain.info/pushtx').to_return(status: 200)
     Sibit::Bin.start(
       [
-        'pay', 'MAX', '100',
+        'pay', 'MAX', '1000',
         'fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2',
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
         'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', '--dry', '--quiet'

--- a/test/test_blockchain.rb
+++ b/test/test_blockchain.rb
@@ -30,6 +30,12 @@ class TestBlockchain < Minitest::Test
     assert_kind_of(Array, json[:txns][0][:outputs])
   end
 
+  def test_never_rounds_small_regular_fee_to_zero
+    stub_request(:get, 'https://api.blockchain.info/mempool/fees')
+      .to_return(body: '{"regular":2,"priority":5,"limits":{"max":10}}')
+    assert_equal(1, Sibit::Blockchain.new.fees[:S], 'small regular fee cannot round down to zero')
+  end
+
   def test_rejects_unknown_currency
     stub_request(:get, 'https://blockchain.info/ticker').to_return(body: '{}')
     assert_raises(Sibit::Error) { Sibit::Blockchain.new.price('XYZ') }

--- a/test/test_sibit.rb
+++ b/test/test_sibit.rb
@@ -158,6 +158,96 @@ class TestSibit < Minitest::Test
     end
   end
 
+  def test_refuses_when_funds_barely_exceed_amount
+    json = {
+      unspent_outputs: [
+        {
+          tx_hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+          tx_hash_big_endian: '5de641d3867eb8fec3eb1a5ef2b44df39b54e0b3bb664ab520f2ae26a5b18ffc',
+          tx_output_n: 0,
+          script: '0014c48a1737b35a9f9d9e3b624a910f1e22f7e80bbc',
+          confirmations: 1,
+          value: 100_000
+        }
+      ]
+    }
+    stub_request(
+      :get,
+      'https://blockchain.info/unspent?active=bc1qcj9pwdant20em83mvf9fzrc7ytm7szau5ysh9x&limit=1000'
+    ).to_return(body: JSON.pretty_generate(json))
+    stub_request(:post, 'https://blockchain.info/pushtx').to_return(status: 200)
+    sibit = Sibit.new(api: Sibit::FirstOf.new([Sibit::Blockchain.new]))
+    assert_raises(Sibit::Error, 'cannot broadcast a near-zero-fee transaction') do
+      sibit.pay(
+        99_999, 100,
+        ['fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2'],
+        sibit.create(sibit.generate), sibit.create(sibit.generate),
+        price: 5000.0
+      )
+    end
+  end
+
+  def test_refuses_when_change_would_be_dust
+    json = {
+      unspent_outputs: [
+        {
+          tx_hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+          tx_hash_big_endian: '5de641d3867eb8fec3eb1a5ef2b44df39b54e0b3bb664ab520f2ae26a5b18ffc',
+          tx_output_n: 0,
+          script: '0014c48a1737b35a9f9d9e3b624a910f1e22f7e80bbc',
+          confirmations: 1,
+          value: 100_000
+        }
+      ]
+    }
+    stub_request(
+      :get,
+      'https://blockchain.info/unspent?active=bc1qcj9pwdant20em83mvf9fzrc7ytm7szau5ysh9x&limit=1000'
+    ).to_return(body: JSON.pretty_generate(json))
+    stub_request(:post, 'https://blockchain.info/pushtx').to_return(status: 200)
+    sibit = Sibit.new(api: Sibit::FirstOf.new([Sibit::Blockchain.new]))
+    assert_raises(Sibit::Error, 'cannot broadcast a transaction with a dust change') do
+      sibit.pay(
+        99_500, 400,
+        ['fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2'],
+        sibit.create(sibit.generate), sibit.create(sibit.generate),
+        price: 5000.0
+      )
+    end
+  end
+
+  def test_refuses_to_sweep_when_fee_leaves_no_room
+    stub_request(
+      :get, 'https://api.blockchain.info/mempool/fees'
+    ).to_return(body: '{"regular":6,"priority":5,"limits":{"max":10}}')
+    json = {
+      unspent_outputs: [
+        {
+          tx_hash: 'fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d',
+          tx_hash_big_endian: '5de641d3867eb8fec3eb1a5ef2b44df39b54e0b3bb664ab520f2ae26a5b18ffc',
+          tx_output_n: 0,
+          script: '0014c48a1737b35a9f9d9e3b624a910f1e22f7e80bbc',
+          confirmations: 1,
+          value: 100_000
+        }
+      ]
+    }
+    stub_request(
+      :get,
+      'https://blockchain.info/unspent?active=bc1qcj9pwdant20em83mvf9fzrc7ytm7szau5ysh9x&limit=1000'
+    ).to_return(body: JSON.pretty_generate(json))
+    stub_request(:post, 'https://blockchain.info/pushtx').to_return(status: 200)
+    sibit = Sibit.new(api: Sibit::FirstOf.new([Sibit::Blockchain.new]))
+    assert_raises(Sibit::Error, 'cannot send the entire balance and still pay a fee') do
+      sibit.pay(
+        100_000, 'S',
+        ['fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2'],
+        sibit.create(sibit.generate), sibit.create(sibit.generate),
+        price: 5000.0
+      )
+    end
+  end
+
   def test_balance_with_trust_sums_confirmed_utxos
     json = {
       unspent_outputs: [

--- a/test/test_txbuilder.rb
+++ b/test/test_txbuilder.rb
@@ -79,7 +79,7 @@ class TestTxBuilder < Minitest::Test
     assert_equal(1, tx.outputs.length, 'tx should have only one output when leave_fee is false')
   end
 
-  def test_skips_change_when_zero_or_negative
+  def test_skips_change_when_exactly_zero
     builder = Sibit::TxBuilder.new
     key = Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
     builder.input do |i|
@@ -94,6 +94,42 @@ class TestTxBuilder < Minitest::Test
       change_address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
     )
     assert_equal(1, tx.outputs.length, 'tx should skip zero change output')
+  end
+
+  def test_rejects_change_that_would_be_negative
+    builder = Sibit::TxBuilder.new
+    key = Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
+    builder.input do |i|
+      i.prev_out('fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d')
+      i.prev_out_index(0)
+      i.prev_out_script = '76a914c14b1e5c95a4687da3f7c932bf39a3a89bdb3fa988ac'
+      i.signature_key(key)
+    end
+    builder.output(99_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_raises(Sibit::Error, 'cannot let the fee silently swallow a negative change') do
+      builder.tx(
+        input_value: 100_000, leave_fee: true, extra_fee: 2000,
+        change_address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+      )
+    end
+  end
+
+  def test_rejects_change_below_dust
+    builder = Sibit::TxBuilder.new
+    key = Sibit::Key.new('fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2')
+    builder.input do |i|
+      i.prev_out('fc8fb1a526aef220b54a66bbb3e0549bf34db4f25e1aebc3feb87e86d341e65d')
+      i.prev_out_index(0)
+      i.prev_out_script = '76a914c14b1e5c95a4687da3f7c932bf39a3a89bdb3fa988ac'
+      i.signature_key(key)
+    end
+    builder.output(98_900, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_raises(Sibit::Error, 'cannot create a dust change output that relays reject') do
+      builder.tx(
+        input_value: 100_000, leave_fee: true, extra_fee: 1000,
+        change_address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+      )
+    end
   end
 
   def test_returns_inputs_via_in_method


### PR DESCRIPTION
Money used to leave the wallet with a fee different from the one requested, and without any error. `TxBuilder#tx` computed `change = input_value - total - extra_fee` and simply skipped the change output when it was not positive, so the shortfall became an unrequested fee — a 1-satoshi or zero-fee transaction that either bounces off the relay floor or sits unconfirmable forever, while `pay` had already returned a txid. A change of `0 < change < 546` produced a dust output that relays also reject after signing.

This makes the builder fail fast: it raises when the inputs cannot cover the outputs plus the fee, and when the change would be dust. Alongside that, `MIN_SATOSHI_PER_BYTE` moves from 0.1 to 1 sat/vB (the real relay floor), and `Blockchain#fees` rounds the `S` tier up so a small `regular` rate no longer collapses to zero via integer division. The CLI `pay MAX` now subtracts the fee from the swept balance, so sweeping stays usable instead of always tripping the new guard.

I left the fee-aware UTXO accumulation loop (`lib/sibit.rb`) as follow-up: it still stops as soon as `unspent > satoshi`, so a wallet whose first UTXOs only just cover the amount now raises honestly rather than gathering more to cover the fee. Happy to tackle that separately if you'd like it in scope.

Closes #291