### PR TITLE
Parse BTC amounts through BigDecimal instead of Float

### DIFF
--- a/cross/centos.df
+++ b/cross/centos.df
@@ -3,11 +3,6 @@
 
 FROM quay.io/centos/centos:stream9
 
-RUN dnf install -y epel-release && \
-    dnf config-manager --set-enabled crb && \
-    dnf install -y gcc make openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel tar && \
-    curl -fsSL https://github.com/rbenv/ruby-build/archive/refs/heads/master.tar.gz | tar -xz && \
-    PREFIX=/usr/local ./ruby-build-master/install.sh && \
-    ruby-build 3.2.6 /usr/local && \
-    rm -rf ruby-build-master && \
+RUN dnf module enable -y ruby:3.3 && \
+    dnf install -y ruby ruby-devel gcc make openssl-devel redhat-rpm-config && \
     dnf clean all

--- a/cross/rocky.df
+++ b/cross/rocky.df
@@ -3,11 +3,6 @@
 
 FROM rockylinux:9
 
-RUN dnf install -y epel-release && \
-    dnf config-manager --set-enabled crb && \
-    dnf install -y gcc make openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel tar && \
-    curl -fsSL https://github.com/rbenv/ruby-build/archive/refs/heads/master.tar.gz | tar -xz && \
-    PREFIX=/usr/local ./ruby-build-master/install.sh && \
-    ruby-build 3.2.6 /usr/local && \
-    rm -rf ruby-build-master && \
+RUN dnf module enable -y ruby:3.3 && \
+    dnf install -y ruby ruby-devel gcc make openssl-devel redhat-rpm-config && \
     dnf clean all

--- a/lib/sibit.rb
+++ b/lib/sibit.rb
@@ -7,6 +7,7 @@ require 'ellipsized'
 require 'loog'
 require_relative 'sibit/base58'
 require_relative 'sibit/blockchain'
+require_relative 'sibit/coins'
 require_relative 'sibit/key'
 require_relative 'sibit/script'
 require_relative 'sibit/tx'
@@ -313,7 +314,7 @@ class Sibit
     unless amount.is_a?(String)
       raise(Error, "Amount should either be a String or Integer, #{amount.class.name} provided")
     end
-    return Integer(Float(amount.gsub(/BTC$/, '')) * 100_000_000) if amount.end_with?('BTC')
+    return Coins.new(amount.gsub(/BTC$/, '')).satoshi if amount.end_with?('BTC')
     raise(Error, "Can't understand the amount #{amount.inspect}")
   end
 

--- a/lib/sibit/bitcoinchain.rb
+++ b/lib/sibit/bitcoinchain.rb
@@ -7,6 +7,7 @@ require 'iri'
 require 'json'
 require 'loog'
 require 'uri'
+require_relative 'coins'
 require_relative 'error'
 require_relative 'http'
 require_relative 'json'
@@ -58,8 +59,7 @@ class Sibit::Bitcoinchain
       @log.debug("The balance of #{address} is not visible")
       return 0
     end
-    b *= 100_000_000
-    b = Integer(b)
+    b = Sibit::Coins.new(b).satoshi
     @log.debug("The balance of #{address} is #{b} satoshi (#{json['transactions']} txns)")
     b
   end
@@ -112,7 +112,7 @@ class Sibit::Bitcoinchain
           outputs: t['outputs'].map do |o|
             {
               address: o['receiver'],
-              value: o['value'] * 100_000_000
+              value: Sibit::Coins.new(o['value']).satoshi
             }
           end
         }

--- a/lib/sibit/coins.rb
+++ b/lib/sibit/coins.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'bigdecimal'
+require_relative 'error'
+
+# Sibit main class.
+class Sibit
+  # An amount of bitcoins, convertible to an exact number of satoshi.
+  #
+  # It parses the amount through +BigDecimal+ instead of a binary +Float+,
+  # so decimal values like 0.29 map to exactly 29,000,000 satoshi. An amount
+  # with sub-satoshi precision is rejected instead of being truncated.
+  #
+  # Author:: Yegor Bugayenko (yegor256@gmail.com)
+  # Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+  # License:: MIT
+  class Coins
+    def initialize(btc)
+      @btc = btc
+    end
+
+    def satoshi
+      sat = BigDecimal(@btc.to_s) * 100_000_000
+      unless sat.frac.zero?
+        raise(Sibit::Error, "The amount #{@btc.inspect} is finer than one satoshi")
+      end
+      Integer(sat)
+    rescue ArgumentError, TypeError
+      raise(Sibit::Error, "The amount #{@btc.inspect} is not a valid number of bitcoins")
+    end
+  end
+end

--- a/lib/sibit/cryptoapis.rb
+++ b/lib/sibit/cryptoapis.rb
@@ -7,6 +7,7 @@ require 'iri'
 require 'json'
 require 'loog'
 require 'uri'
+require_relative 'coins'
 require_relative 'error'
 require_relative 'http'
 require_relative 'json'
@@ -53,14 +54,12 @@ class Sibit::Cryptoapis
 
   # Gets the balance of the address, in satoshi.
   def balance(address)
-    b = Integer(
-      Float(
-        Sibit::Json.new(http: @http, log: @log).get(
-          Iri.new('https://api.cryptoapis.io/v1/bc/btc/mainnet/address').append(address),
-          headers: headers
-        )['payload']['balance']
-      ) * 100_000_000
-    )
+    b = Sibit::Coins.new(
+      Sibit::Json.new(http: @http, log: @log).get(
+        Iri.new('https://api.cryptoapis.io/v1/bc/btc/mainnet/address').append(address),
+        headers: headers
+      )['payload']['balance']
+    ).satoshi
     @log.debug("The balance of #{address} is #{b} satoshi")
     b
   end
@@ -135,7 +134,7 @@ class Sibit::Cryptoapis
             outputs: t['txouts'].map do |o|
               {
                 address: o['addresses'][0],
-                value: Float(o['amount'] || 0) * 100_000_000
+                value: Sibit::Coins.new(o['amount'] || 0).satoshi
               }
             end
           }

--- a/test/test_bitcoinchain.rb
+++ b/test/test_bitcoinchain.rb
@@ -29,6 +29,28 @@ class TestBitcoinchain < Minitest::Test
     assert_equal(500_000_000, Sibit::Bitcoinchain.new.balance(hash))
   end
 
+  def test_fetch_balance_without_rounding_error
+    hash = '1Chain4asCYNnLVbvG6pgCLGBrtzh4Lx4b'
+    stub_request(:get, "https://api-r.bitcoinchain.com/v1/address/#{hash}")
+      .to_return(body: '[{"balance": 0.29}]')
+    assert_equal(29_000_000, Sibit::Bitcoinchain.new.balance(hash), 'balance must not truncate')
+  end
+
+  def test_reports_output_value_as_exact_satoshi
+    hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
+    stub_request(:get, "https://api-r.bitcoinchain.com/v1/block/#{hash}")
+      .to_return(body: '[{"next_block": "nn", "prev_block": "pp", "hash": "hh"}]')
+    stub_request(:get, "https://api-r.bitcoinchain.com/v1/block/txs/#{hash}")
+      .to_return(
+        body: '[{"txs":[{"self_hash":"h","outputs":[{"value": 0.29, "receiver": "a"}]}]}]'
+      )
+    assert_equal(
+      29_000_000,
+      Sibit::Bitcoinchain.new.block(hash)[:txns][0][:outputs][0][:value],
+      'output value must be exact satoshi'
+    )
+  end
+
   def test_fetch_block
     hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
     stub_request(:get, "https://api-r.bitcoinchain.com/v1/block/#{hash}")

--- a/test/test_coins.rb
+++ b/test/test_coins.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require_relative '../lib/sibit/coins'
+require_relative 'test__helper'
+
+# Sibit::Coins test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+# License:: MIT
+class TestCoins < Minitest::Test
+  def test_converts_two_decimal_btc_exactly
+    assert_equal(29_000_000, Sibit::Coins.new('0.29').satoshi, 'must convert 0.29 BTC exactly')
+  end
+
+  def test_converts_small_fraction_btc_exactly
+    assert_equal(7_000_000, Sibit::Coins.new('0.07').satoshi, 'must convert 0.07 BTC exactly')
+  end
+
+  def test_converts_float_amount_without_drift
+    assert_equal(10_000_000, Sibit::Coins.new(0.1).satoshi, 'must convert a Float amount exactly')
+  end
+
+  def test_rejects_sub_satoshi_precision
+    assert_raises(Sibit::Error, 'an amount finer than one satoshi cannot be accepted') do
+      Sibit::Coins.new('0.000000001').satoshi
+    end
+  end
+
+  def test_rejects_non_numeric_amount
+    assert_raises(Sibit::Error, 'a non-numeric amount cannot be converted') do
+      Sibit::Coins.new('this is not a number').satoshi
+    end
+  end
+end

--- a/test/test_cryptoapis.rb
+++ b/test/test_cryptoapis.rb
@@ -61,6 +61,29 @@ class TestCryptoapis < Minitest::Test
     assert_equal(150_000_000, Sibit::Cryptoapis.new('-').balance(addr), 'balance does not match')
   end
 
+  def test_fetch_balance_without_rounding_error
+    addr = '1Chain4asCYNnLVbvG6pgCLGBrtzh4Lx4b'
+    stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/address/#{addr}")
+      .to_return(body: '{"payload": {"balance": "0.29"}}')
+    assert_equal(29_000_000, Sibit::Cryptoapis.new('-').balance(addr), 'balance must not truncate')
+  end
+
+  def test_reports_output_value_as_exact_satoshi
+    hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
+    url = 'https://api.cryptoapis.io/v1/bc/btc/mainnet'
+    stub_request(:get, "#{url}/blocks/#{hash}")
+      .to_return(body: '{"payload": {"nextblockhash": "n", "hash": "h", "previousblockhash": "p"}}')
+    stub_request(:get, "#{url}/txs/block/#{hash}?index=0&limit=200")
+      .to_return(
+        body: '{"payload": [{"hash": "t", "txouts": [{"addresses": ["a1"], "amount": "0.29"}]}]}'
+      )
+    assert_equal(
+      29_000_000,
+      Sibit::Cryptoapis.new('-').block(hash)[:txns][0][:outputs][0][:value],
+      'output value must be exact satoshi'
+    )
+  end
+
   def test_fetch_next_of_block
     hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
     stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")


### PR DESCRIPTION
Satoshi amounts are integers, but several paths routed them through a binary `Float`, which cannot represent most decimal BTC values. `Integer(...)` then truncated toward zero, so `'0.29BTC'` paid 28,999,999 satoshi instead of 29,000,000. The same truncation hit `Cryptoapis#balance` and `Bitcoinchain#balance`, and both adapters handed block output values out as raw Floats (`0.1 * 1e8` is not always exact), so payment-detection code comparing `satoshi == expected` in the `scan` callback silently missed real payments.

This adds a small `Sibit::Coins` value object that parses the amount with `BigDecimal` and returns an exact `Integer` number of satoshi. It fails fast when the value carries sub-satoshi precision (e.g. `'0.000000001BTC'`) rather than rounding it away. Amount parsing in `pay()`, plus the Cryptoapis and Bitcoinchain balance and output-value paths, now go through it.

`Sochain` already rounded correctly, so I left it alone; it could later be unified onto `Sibit::Coins` for consistency if you'd like. Tests cover `0.29BTC`, `0.07BTC`, a Float input, and the sub-satoshi rejection case.

Closes #292