### PR TITLE
feat: #313 live test that signs and pushes a real mainnet self-send

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -27,3 +27,5 @@ jobs:
       - run: bundle config set --global path "$(pwd)/vendor/bundle"
       - run: bundle install --no-color
       - run: bundle exec rake
+        env:
+          REAL_PRIVATE_KEY: ${{ secrets.REAL_PRIVATE_KEY }}

--- a/test/test_realpay.rb
+++ b/test/test_realpay.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2019-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+
+require 'backtrace'
+require 'webmock/minitest'
+require_relative '../lib/sibit'
+require_relative '../lib/sibit/blockchain'
+require_relative '../lib/sibit/key'
+require_relative 'test__helper'
+
+# Live payment test that signs and pushes a real mainnet transaction.
+#
+# This test only runs when the +REAL_PRIVATE_KEY+ environment variable is
+# present and the derived address holds a positive, confirmed balance. It
+# sweeps the entire balance back to the same address, which means every run
+# only costs the miners fee. The transaction size and the minimum
+# one-satoshi-per-byte fee are estimated exactly the way +Sibit#pay+ does,
+# so the change output lands on zero and the whole balance is swept. Repeated
+# runs re-spend the same UTXOs while the previous transaction is still in the
+# mempool, so a mempool-conflict or "already known" response from the provider
+# is treated as success.
+#
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2019-2026 Yegor Bugayenko
+# License:: MIT
+class TestRealPay < Minitest::Test
+  TOLERATED = Regexp.union(
+    /already\s*(known|exists|in\s*(the\s*)?(block|mempool))/i,
+    /txn-already-(known|in-mempool)/i,
+    /txn-mempool-conflict/i,
+    /missing\s*inputs/i,
+    /bad-txns-inputs-missingorspent/i
+  )
+
+  def test_signs_and_pushes_real_self_send
+    key = ENV.fetch('REAL_PRIVATE_KEY', nil)
+    skip('REAL_PRIVATE_KEY is not set') if key.nil? || key.empty?
+    WebMock.allow_net_connect!
+    api = Sibit::Blockchain.new
+    sibit = Sibit.new(api: api)
+    addr = Sibit::Key.new(key).bech32
+    utxos = api.utxos([addr]).select { |u| Integer(u[:confirmations] || 0, 10).positive? }
+    balance = utxos.sum { |u| u[:value] }
+    skip("The balance of #{addr} is zero, nothing to send") if balance.zero?
+    size = 100 + (utxos.count * 180)
+    fee = size * Sibit::MIN_SATOSHI_PER_BYTE
+    hash = sibit.pay(balance - fee, 1, [key], addr, addr)
+    assert_match(/^[0-9a-f]{64}$/, hash, 'a real transaction hash must be returned')
+  rescue Sibit::Error => e
+    raise unless TOLERATED.match?(e.message)
+    puts(Backtrace.new(e))
+    skip("The transaction was rejected as a duplicate/conflict, which is fine: #{e.message}")
+  end
+end

--- a/test/test_realpay.rb
+++ b/test/test_realpay.rb
@@ -41,7 +41,7 @@ class TestRealPay < Minitest::Test
     api = Sibit::Blockchain.new
     sibit = Sibit.new(api: api)
     addr = Sibit::Key.new(key).bech32
-    utxos = api.utxos([addr]).select { |u| Integer(u[:confirmations] || 0, 10).positive? }
+    utxos = api.utxos([addr]).select { |u| u[:confirmations]&.positive? }
     balance = utxos.sum { |u| u[:value] }
     skip("The balance of #{addr} is zero, nothing to send") if balance.zero?
     size = 100 + (utxos.count * 180)


### PR DESCRIPTION
Closes #313.

## What

Adds `test/test_realpay.rb` — the first test to exercise the full real-network path (fetch UTXOs → build → sign → `push`) against a live mainnet provider. Until now `test/test_regtest.rb` covered the whole flow but only against local Bitcoin Core in Docker, and `test/test_live.rb` hit real providers for read-only queries only.

## How it works

Modeled on `test_live.rb`'s `skip` / `WebMock.allow_net_connect!` pattern:

- **Skips** unless `REAL_PRIVATE_KEY` is set and the derived address holds a positive, confirmed balance.
- Fetches the confirmed UTXOs, then estimates the transaction `size` (`100 + 180 * n`) and the `1`-sat/byte fee **exactly the way `Sibit#pay` does**.
- Calls `pay(balance - fee, 1, [key], addr, addr)` — a self-send. Setting `amount = balance - fee` lands the change output on exactly `0`, so `pay`'s early-break sweep consumes every UTXO and the dust guard (`txbuilder.rb:59`) is never tripped.
- Asserts the returned hash matches `/^[0-9a-f]{64}$/`.
- **Tolerates** a mempool-conflict / "already known" response as a pass, since back-to-back runs re-spend the same UTXOs while the prior transaction is still unconfirmed. Repeated runs only erode the balance on fees, which is acceptable.

## CI wiring

`REAL_PRIVATE_KEY` is wired into `.github/workflows/rake.yml` as an env var sourced from the repository secret. Secrets are unavailable to fork PRs, so those runs skip automatically.

## Notes

The issue's "smallest fee possible guarantees non-processing" premise doesn't hold: `pay` floors the paid fee at `size * MIN_SATOSHI_PER_BYTE` (with `MIN_SATOSHI_PER_BYTE = 1`), so a 1-sat/byte transaction is relayable and accepted — it just confirms slowly. A genuinely sub-relay fee would be rejected outright and fail the very "accepted by a provider" assertion. Since this is a self-send, confirmation only costs the fee, so the test targets an accepted-and-relayable transaction rather than a non-processing one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATE1UuJjKu7jkqgxEiFJq7)_