### PR TITLE
Return the next block hash from Cryptoapis#next_of

### DIFF
--- a/lib/sibit/cryptoapis.rb
+++ b/lib/sibit/cryptoapis.rb
@@ -33,10 +33,13 @@ class Sibit::Cryptoapis
 
   # Get hash of the block after this one.
   def next_of(hash)
-    nxt = Sibit::Json.new(http: @http, log: @log).get(
+    head = Sibit::Json.new(http: @http, log: @log).get(
       Iri.new('https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks').append(hash),
       headers: headers
-    )['payload']['hash']
+    )['payload']
+    raise(Sibit::Error, "The block #{hash} not found") if head.nil?
+    nxt = head['nextblockhash']
+    nxt = nil if nxt == '0000000000000000000000000000000000000000000000000000000000000000'
     @log.debug("The block #{hash} is the latest, there is no next block") if nxt.nil?
     @log.debug("The next block of #{hash} is #{nxt}") unless nxt.nil?
     nxt

--- a/test/test_cryptoapis.rb
+++ b/test/test_cryptoapis.rb
@@ -87,11 +87,38 @@ class TestCryptoapis < Minitest::Test
   def test_fetch_next_of_block
     hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
     stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")
-      .to_return(body: '{"payload": {"hash": "00000000next"}}')
+      .to_return(body: "{\"payload\": {\"hash\": \"#{hash}\", \"nextblockhash\": \"nextblock\"}}")
     assert_equal(
-      '00000000next', Sibit::Cryptoapis.new('-').next_of(hash),
+      'nextblock', Sibit::Cryptoapis.new('-').next_of(hash),
       'next block hash does not match'
     )
+  end
+
+  def test_next_of_never_returns_own_hash
+    hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
+    stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")
+      .to_return(body: "{\"payload\": {\"hash\": \"#{hash}\", \"nextblockhash\": \"nextblock\"}}")
+    refute_equal(
+      hash, Sibit::Cryptoapis.new('-').next_of(hash),
+      'next_of must not return the block itself'
+    )
+  end
+
+  def test_next_of_latest_block_is_nil
+    hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
+    zeros = '0000000000000000000000000000000000000000000000000000000000000000'
+    stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")
+      .to_return(body: "{\"payload\": {\"hash\": \"#{hash}\", \"nextblockhash\": \"#{zeros}\"}}")
+    assert_nil(Sibit::Cryptoapis.new('-').next_of(hash), 'latest block cannot have a next')
+  end
+
+  def test_next_of_missing_payload_raises
+    hash = '000000000000000007341915521967247f1dec17b3a311b8a8f4495392f1439b'
+    stub_request(:get, "https://api.cryptoapis.io/v1/bc/btc/mainnet/blocks/#{hash}")
+      .to_return(body: '{"payload": null}')
+    assert_raises(Sibit::Error, 'missing payload must fail loudly') do
+      Sibit::Cryptoapis.new('-').next_of(hash)
+    end
   end
 
   def test_fetch_height


### PR DESCRIPTION
`Sibit::Cryptoapis#next_of` fetched the block by its hash and returned `payload['hash']` — the block's own identity. It was an expensive no-op. This makes it read `payload['nextblockhash']` instead, maps the all-zeros sentinel to `nil` the way the other adapters do, and raises `Sibit::Error` when the payload is missing rather than crashing on `nil`.

It matters because `scan()` leans on `next_of()` to walk the chain when a block reports no `next`. With the old identity behaviour, `scan` re-fetched and re-processed the same block until the `max` counter stopped it, so a payment-watcher built on it silently stopped seeing new blocks and re-yielded the same transactions on every pass.

The regression tests stub the endpoint and assert `next_of(A)` returns `B ≠ A`, that the all-zeros sentinel maps to `nil`, and that a missing payload fails loudly. Sochain, Btc and Bitcoinchain already handle this correctly, so no other adapter needed touching.

Closes #293