### PR TITLE
Select UTXOs deterministically in pay() to stop retries double-paying

### DIFF
--- a/lib/sibit.rb
+++ b/lib/sibit.rb
@@ -97,9 +97,13 @@ class Sibit
   #
   # If the payment can't be signed (the key is wrong, for example) or the
   # previous transaction is not found, or there is a network error, or
-  # any other reason, you will get an exception. In this case, just try again.
-  # It's safe to try as many times as you need. Don't worry about duplicating
-  # your transaction, the Bitcoin network will filter duplicates out.
+  # any other reason, you will get an exception. You may retry, but only
+  # while no earlier attempt could have reached the network: inputs are
+  # selected deterministically, so an immediate retry rebuilds a conflicting
+  # transaction that the network rejects as a double-spend. Once an earlier
+  # attempt might have confirmed, the wallet holds a fresh set of UTXOs and
+  # a blind retry may pay the target twice; check the target address (or the
+  # previous transaction hash) before re-sending.
   #
   # If there are more than 1000 UTXOs in the address where you are trying
   # to send bitcoins from, this method won't be helpful.
@@ -151,7 +155,7 @@ class Sibit
     builder = TxBuilder.new
     unspent = 0
     size = 100
-    utxos = @api.utxos(sources.keys)
+    utxos = @api.utxos(sources.keys).sort_by { |u| [u[:hash], u[:index]] }
     @log.debug("#{utxos.count} UTXOs found, these will be used (value/confirmations at tx_hash):")
     utxos.each do |utxo|
       if skip_utxo.include?(utxo[:hash])

--- a/test/test_sibit.rb
+++ b/test/test_sibit.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'json'
+require 'stringio'
 require 'webmock/minitest'
 require_relative '../lib/sibit'
 require_relative '../lib/sibit/bestof'
@@ -11,6 +12,24 @@ require_relative '../lib/sibit/blockchain'
 require_relative '../lib/sibit/fake'
 require_relative '../lib/sibit/firstof'
 require_relative 'test__helper'
+
+# A blockchain API that serves a fixed set of UTXOs and remembers the
+# transaction pushed to it, for asserting how pay() selected its inputs.
+class FakeChain
+  attr_reader :pushed
+
+  def initialize(utxos)
+    @utxos = utxos
+  end
+
+  def utxos(_sources)
+    @utxos
+  end
+
+  def push(hex)
+    @pushed = hex
+  end
+end
 
 # Sibit.
 # Author:: Yegor Bugayenko (yegor256@gmail.com)
@@ -103,6 +122,23 @@ class TestSibit < Minitest::Test
     )
     refute_nil(tx)
     assert_operator(tx.length, :>, 30, tx)
+  end
+
+  def test_retry_with_reordered_utxos_conflicts
+    src = 'fd2333686f49d8647e1ce8d5ef39c304520b08f3c756b67068b30a3db217dcb2'
+    script = '0014c48a1737b35a9f9d9e3b624a910f1e22f7e80bbc'
+    one = { hash: 'aa' * 32, index: 0, script: script, value: 100_000, confirmations: 6 }
+    two = { hash: 'bb' * 32, index: 0, script: script, value: 100_000, confirmations: 6 }
+    first = FakeChain.new([one, two])
+    second = FakeChain.new([two, one])
+    target = Sibit.new.create(Sibit.new.generate)
+    change = Sibit.new.create(Sibit.new.generate)
+    Sibit.new(api: first).pay(50_000, 1000, [src], target, change, price: 5000.0)
+    Sibit.new(api: second).pay(50_000, 1000, [src], target, change, price: 5000.0)
+    refute_empty(
+      outpoints(first.pushed) & outpoints(second.pushed),
+      'a retry with reordered UTXOs must reuse an input so the network rejects the double-spend'
+    )
   end
 
   def test_send_payment_with_xl_minus_fee
@@ -344,5 +380,18 @@ class TestSibit < Minitest::Test
       end
     assert(found)
     assert_equal('next', tail)
+  end
+
+  private
+
+  def outpoints(hex)
+    io = StringIO.new([hex].pack('H*'))
+    io.read(6)
+    Array.new(io.read(1).unpack1('C')) do
+      out = [io.read(32).reverse.unpack1('H*'), io.read(4).unpack1('V')]
+      io.read(io.read(1).unpack1('C'))
+      io.read(4)
+      out
+    end
   end
 end


### PR DESCRIPTION
`pay()` re-fetched the UTXO set on every call and consumed it in whatever order the API returned, stopping as soon as the amount was covered. For a wallet whose UTXOs comfortably exceed the amount, two attempts — or two providers behind `FirstOf`, which the CLI uses by default — could land on *disjoint* subsets. Both transactions were then valid, both confirmed, and the target got paid twice. That's real money lost by following exactly the "just try again, it's safe" recovery the docs promised.

This sorts the UTXOs by `[hash, index]` before selection, so as long as the wallet state hasn't changed, a retry rebuilds a transaction that spends the same inputs and the network rejects it as a double-spend — restoring the "duplicates get filtered" property for the common retry case. The `pay()` docblock no longer claims unconditional retry safety; it now says retries are safe only until an earlier attempt might have confirmed, and to check the target address (or the previous txid) before re-sending.

The regression test serves the same two UTXOs in opposite orders to two `pay()` runs and asserts the two transactions share an input. Deterministic selection is only half the story: fully byte-identical retries would still need an idempotency key (caller-supplied outpoints), and a push whose response was lost can still double-pay once the first tx confirms — both noted in the issue as larger follow-ups, left out here on purpose.

Closes #294