### PR TITLE
Emit one UTXO per unspent entry, honoring tx_output_n

### DIFF
--- a/lib/sibit/btc.rb
+++ b/lib/sibit/btc.rb
@@ -100,19 +100,19 @@ class Sibit::Btc
       list = data['list']
       next if list.nil?
       list.each do |u|
-        outs = Sibit::Json.new(http: @http, log: @log).get(
+        index = u['tx_output_n']
+        raise(Sibit::Error, "The unspent output of #{hash} has no tx_output_n") if index.nil?
+        out = Sibit::Json.new(http: @http, log: @log).get(
           Iri.new('https://chain.api.btc.com/v3/tx').append(u['tx_hash']).add(verbose: 3)
-        )['data']['outputs']
-        outs.each_with_index do |o, i|
-          next unless o['addresses'].include?(hash)
-          results << {
-            value: o['value'],
-            hash: u['tx_hash'],
-            index: i,
-            confirmations: u['confirmations'],
-            script: [o['script_hex']].pack('H*')
-          }
-        end
+        )['data']['outputs'][index]
+        raise(Sibit::Error, "The output #{index} of #{u['tx_hash']} is absent") if out.nil?
+        results << {
+          value: u['value'],
+          hash: u['tx_hash'],
+          index: index,
+          confirmations: u['confirmations'],
+          script: [out['script_hex']].pack('H*')
+        }
       end
     end
     results

--- a/test/test_btc.rb
+++ b/test/test_btc.rb
@@ -201,7 +201,7 @@ class TestBtc < Minitest::Test
     addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
       .to_return(
-        body: '{"data":{"list":[{"tx_hash":"aa","confirmations":5}]}}'
+        body: '{"data":{"list":[{"tx_hash":"aa","tx_output_n":0,"value":42,"confirmations":5}]}}'
       )
     stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
       .to_return(
@@ -222,9 +222,13 @@ class TestBtc < Minitest::Test
     one = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
     two = '1JSQBzkELK8UA9NVm4sZJ1CWGLEp8zUxR6'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{one}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"aa","confirmations":3}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"aa","tx_output_n":0,"value":11,"confirmations":3}]}}'
+      )
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{two}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"bb","confirmations":4}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"bb","tx_output_n":0,"value":22,"confirmations":4}]}}'
+      )
     stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
       .to_return(
         body: %({"data":{"outputs":[{"addresses":["#{one}"],"value":11,"script_hex":"00"}]}})
@@ -243,7 +247,9 @@ class TestBtc < Minitest::Test
     addr = '1MZT1fa6y8H9UmbZV6HqKF4UY41o9MGT5f'
     other = '1OtherAddrCCCCCCCCCCCCCCCCCCCCCCCC'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"aa","confirmations":1}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"aa","tx_output_n":1,"value":7,"confirmations":1}]}}'
+      )
     stub_request(:get, 'https://chain.api.btc.com/v3/tx/aa?verbose=3')
       .to_return(
         body: %({"data":{"outputs":[
@@ -286,9 +292,13 @@ class TestBtc < Minitest::Test
     alpha = '1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
     beta = '1BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{alpha}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"aaaa","confirmations":3}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"aaaa","tx_output_n":0,"value":100,"confirmations":3}]}}'
+      )
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{beta}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"bbbb","confirmations":7}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"bbbb","tx_output_n":0,"value":200,"confirmations":7}]}}'
+      )
     stub_request(:get, 'https://chain.api.btc.com/v3/tx/aaaa?verbose=3').to_return(
       body: %({"data":{"outputs":[{"addresses":["#{alpha}"],"value":100,"script_hex":"dead"}]}})
     )
@@ -307,7 +317,9 @@ class TestBtc < Minitest::Test
     mine = '1CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
     other = '1DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{mine}/unspent")
-      .to_return(body: '{"data":{"list":[{"tx_hash":"cccc","confirmations":1}]}}')
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"cccc","tx_output_n":1,"value":75,"confirmations":1}]}}'
+      )
     stub_request(:get, 'https://chain.api.btc.com/v3/tx/cccc?verbose=3')
       .to_return(
         body: %({"data":{"outputs":[
@@ -332,5 +344,75 @@ class TestBtc < Minitest::Test
     mine = '1FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF'
     stub_request(:get, "https://chain.api.btc.com/v3/address/#{mine}/unspent").to_return(body: '{}')
     assert_raises(Sibit::Error) { Sibit::Btc.new.utxos([mine]) }
+  end
+
+  def test_utxos_emits_only_the_unspent_output
+    addr = '1FundedTwiceAAAAAAAAAAAAAAAAAAAAAA'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"ff","tx_output_n":3,"value":1000,"confirmations":6}]}}'
+      )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/ff?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[
+          {"addresses":["#{addr}"],"value":500,"script_hex":"aa"},
+          {"addresses":["1Other"],"value":10,"script_hex":"bb"},
+          {"addresses":["1Other"],"value":10,"script_hex":"cc"},
+          {"addresses":["#{addr}"],"value":1000,"script_hex":"dd"}
+        ]}})
+      )
+    assert_equal(
+      1, Sibit::Btc.new.utxos([addr]).length,
+      'a spent sibling output cannot be emitted as spendable'
+    )
+  end
+
+  def test_utxos_takes_index_from_tx_output_n
+    addr = '1FundedTwiceBBBBBBBBBBBBBBBBBBBBBB'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(
+        body: '{"data":{"list":[{"tx_hash":"ff","tx_output_n":3,"value":1000,"confirmations":6}]}}'
+      )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/ff?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[
+          {"addresses":["#{addr}"],"value":500,"script_hex":"aa"},
+          {"addresses":["1Other"],"value":10,"script_hex":"bb"},
+          {"addresses":["1Other"],"value":10,"script_hex":"cc"},
+          {"addresses":["#{addr}"],"value":1000,"script_hex":"dd"}
+        ]}})
+      )
+    assert_equal(3, Sibit::Btc.new.utxos([addr])[0][:index], 'the index must come from tx_output_n')
+  end
+
+  def test_utxos_never_duplicates_multi_output_funding
+    addr = '1FundedTwiceCCCCCCCCCCCCCCCCCCCCCC'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(
+        body: %({"data":{"list":[
+          {"tx_hash":"ee","tx_output_n":0,"value":100,"confirmations":2},
+          {"tx_hash":"ee","tx_output_n":1,"value":200,"confirmations":2}
+        ]}})
+      )
+    stub_request(:get, 'https://chain.api.btc.com/v3/tx/ee?verbose=3')
+      .to_return(
+        body: %({"data":{"outputs":[
+          {"addresses":["#{addr}"],"value":100,"script_hex":"aa"},
+          {"addresses":["#{addr}"],"value":200,"script_hex":"bb"}
+        ]}})
+      )
+    assert_equal(
+      [0, 1], Sibit::Btc.new.utxos([addr]).map { |u| u[:index] },
+      'each unspent outpoint cannot appear more than once'
+    )
+  end
+
+  def test_utxos_raises_when_tx_output_n_missing
+    addr = '1NoIndexDDDDDDDDDDDDDDDDDDDDDDDDDDD'
+    stub_request(:get, "https://chain.api.btc.com/v3/address/#{addr}/unspent")
+      .to_return(body: '{"data":{"list":[{"tx_hash":"aa","value":5,"confirmations":1}]}}')
+    assert_raises(Sibit::Error, 'a missing tx_output_n cannot be guessed') do
+      Sibit::Btc.new.utxos([addr])
+    end
   end
 end


### PR DESCRIPTION
`Btc#utxos` ignored each unspent entry's `tx_output_n`. Instead of trusting the unspent list, it fetched the whole funding transaction and emitted every output that paid the address. When a transaction paid the address at more than one index, that misbehaves in two ways: it re-emits already-spent sibling outputs as spendable (so `pay()` signs an outpoint that is gone, and the push is rejected after the amount/fee math already looked successful), and it duplicates unspent outpoints (four records for two outputs, each outpoint twice), so `pay()` overcounts the available money and can build a transaction with duplicate inputs. The bad numbers also leak into `balance(address, trust:)`, which sums these values and overstates the balance.

Now it trusts the unspent list: exactly one record per entry, indexed by `tx_output_n` with the entry's own `value`. It still fetches the funding transaction, but only to read that one output's script for signing, and it raises `Sibit::Error` when `tx_output_n` is missing rather than guessing an index.

Regression tests cover a funding tx paying the same address at two indexes (one spent), a multi-output funding tx that must not duplicate, the index coming from `tx_output_n`, and the missing-`tx_output_n` guard. This is a different defect from the closed #245 (which fixed the accumulator being overwritten); the index and spent-output logic survived that fix.

Closes #296