### PR TITLE
Fail fast on bare txids and missing unspent data in Sochain

### DIFF
--- a/lib/sibit/sochain.rb
+++ b/lib/sibit/sochain.rb
@@ -111,9 +111,9 @@ class Sibit::Sochain
       data = Sibit::Json.new(http: @http, log: @log).get(
         Iri.new('https://sochain.com/api/v2/get_tx_unspent').append(@network).append(address)
       )['data']
-      next if data.nil?
+      raise(Sibit::Error, "The address #{address} unspent lookup returned no data") if data.nil?
       txs = data['txs']
-      next if txs.nil?
+      raise(Sibit::Error, "The address #{address} unspent lookup returned no txs") if txs.nil?
       txs.each do |u|
         out << {
           value: Integer((Float(u['value']) * 100_000_000).round),
@@ -162,9 +162,12 @@ class Sibit::Sochain
       next: nxt,
       previous: data['previous_blockhash'],
       txns: (data['txs'] || []).map do |t|
+        unless t.is_a?(Hash)
+          raise(Sibit::NotSupportedError, "SoChain returned bare txid #{t} without outputs")
+        end
         {
-          hash: t['txid'] || t,
-          outputs: ((t.is_a?(Hash) ? t['outputs'] : nil) || []).map do |o|
+          hash: t['txid'],
+          outputs: (t['outputs'] || []).map do |o|
             {
               address: o['address'],
               value: Integer((Float(o['value']) * 100_000_000).round)

--- a/test/test_sochain.rb
+++ b/test/test_sochain.rb
@@ -121,10 +121,52 @@ class TestSochain < Minitest::Test
     assert_equal(7, utxos.first[:confirmations])
   end
 
-  def test_utxos_skips_addresses_without_data
+  def test_utxos_raises_without_data
     stub_request(:get, 'https://sochain.com/api/v2/get_tx_unspent/BTC/1NoData')
       .to_return(body: JSON.generate(status: 'fail', data: nil))
-    assert_equal([], Sibit::Sochain.new.utxos(['1NoData']))
+    assert_raises(Sibit::Error, 'a failed unspent lookup cannot pass as no UTXOs') do
+      Sibit::Sochain.new.utxos(['1NoData'])
+    end
+  end
+
+  def test_utxos_raises_without_txs
+    stub_request(:get, 'https://sochain.com/api/v2/get_tx_unspent/BTC/1Empty')
+      .to_return(body: JSON.generate(status: 'success', data: {}))
+    assert_raises(Sibit::Error, 'a missing txs list cannot pass as no UTXOs') do
+      Sibit::Sochain.new.utxos(['1Empty'])
+    end
+  end
+
+  def test_block_reads_outputs
+    body = JSON.generate(
+      status: 'success',
+      data: {
+        blockhash: BLOCK,
+        is_orphan: false,
+        next_blockhash: '00next',
+        previous_blockhash: '00prev',
+        txs: [{ txid: 'deadbeef', outputs: [{ address: ADDR, value: '0.00000123' }] }]
+      }
+    )
+    stub_request(:get, "https://sochain.com/api/v2/block/BTC/#{BLOCK}").to_return(body: body)
+    assert_equal(123, Sibit::Sochain.new.block(BLOCK)[:txns][0][:outputs][0][:value])
+  end
+
+  def test_block_raises_on_bare_txids
+    body = JSON.generate(
+      status: 'success',
+      data: {
+        blockhash: BLOCK,
+        is_orphan: false,
+        next_blockhash: '00next',
+        previous_blockhash: '00prev',
+        txs: %w[deadbeef cafebabe]
+      }
+    )
+    stub_request(:get, "https://sochain.com/api/v2/block/BTC/#{BLOCK}").to_return(body: body)
+    assert_raises(Sibit::NotSupportedError, 'bare txids cannot pass as a block of empty txns') do
+      Sibit::Sochain.new.block(BLOCK)
+    end
   end
 
   def test_fees_raises_not_supported


### PR DESCRIPTION
`Sibit::Sochain#block` hedged on the shape of the `txs` array. SoChain's block endpoint sometimes returns `txs` as bare txid strings instead of objects with outputs, and in that case the method produced `outputs: []` for every transaction. No exception, no log line — just a well-formed block with zero outputs. `scan()` then processed block after block reporting nothing while advancing its cursor, so real incoming payments were permanently skipped. For a merchant that reads as "nobody paid", the worst failure this kind of code can have.

The block method now raises `NotSupportedError` when it meets a bare txid, so `FirstOf` falls through to an adapter that can enumerate outputs rather than fabricating an empty list. In the same spirit, `utxos` no longer swallows a failed lookup for one source address with `next` — it raises `Sibit::Error` when the API responds without `data` or `txs`, instead of quietly shrinking the spendable set.

A webmock regression feeds a block whose `txs` are strings and asserts `block()` raises; another locks in the happy path where `txs` carry real outputs. Two more cover the `utxos` no-data and no-txs cases.

Closes #297