### PR TITLE
Require a strict majority in BestOf and short-circuit its push

### DIFF
--- a/lib/sibit/bestof.rb
+++ b/lib/sibit/bestof.rb
@@ -66,11 +66,26 @@ class Sibit::BestOf
     best_of('latest', &:latest)
   end
 
-  # Push this transaction (in hex format) to the network.
+  # Push this transaction (in hex format) to the network. This one does
+  # not vote: pushing is a side effect, so it hands the transaction to
+  # each API in turn and stops at the first that accepts it.
   def push(hex)
-    best_of('push') do |api|
-      api.push(hex)
+    return @list.push(hex) unless @list.is_a?(Array)
+    errors = []
+    @list.each do |api|
+      return api.push(hex)
+    rescue Sibit::NotSupportedError
+      nil
+    rescue Sibit::Error => e
+      errors << e
+      @log.debug("The API #{api.class.name} failed at push(): #{e.message}") if @verbose
     end
+    errors.each { |e| @log.debug(Backtrace.new(e).to_s) }
+    raise(
+      Sibit::Error,
+      "No APIs out of #{@list.length} managed to succeed at push(): " \
+      "#{@list.map { |a| a.class.name }.join(', ')}"
+    )
   end
 
   # This method should fetch a block and return as a hash.
@@ -84,17 +99,17 @@ class Sibit::BestOf
 
   def best_of(method)
     return yield(@list) unless @list.is_a?(Array)
-    results = []
+    votes = []
     errors = []
     @list.each do |api|
-      results << yield(api)
+      votes << [api.class.name, yield(api)]
     rescue Sibit::NotSupportedError
       nil
     rescue Sibit::Error => e
       errors << e
       @log.debug("The API #{api.class.name} failed at #{method}(): #{e.message}") if @verbose
     end
-    if results.empty?
+    if votes.empty?
       errors.each { |e| @log.debug(Backtrace.new(e).to_s) }
       raise(
         Sibit::Error,
@@ -102,6 +117,18 @@ class Sibit::BestOf
         "#{@list.map { |a| a.class.name }.join(', ')}"
       )
     end
-    results.group_by(&:to_s).values.max_by(&:size)[0]
+    majority(method, votes)
+  end
+
+  def majority(method, votes)
+    winner = votes.group_by { |v| v[1].to_s }.values.max_by(&:size)
+    if winner.size <= votes.size / 2
+      raise(
+        Sibit::Error,
+        "No strict majority among #{votes.size} answers at #{method}(): " \
+        "#{votes.map { |name, answer| "#{name}=#{answer}" }.join(', ')}"
+      )
+    end
+    winner[0][1]
   end
 end

--- a/test/test_bestof.rb
+++ b/test/test_bestof.rb
@@ -42,4 +42,50 @@ class TestBestOf < Minitest::Test
       sibit.latest
     end
   end
+
+  def test_raises_on_disagreement_without_majority
+    low = Class.new do
+      def balance(_address)
+        0
+      end
+    end.new
+    high = Class.new do
+      def balance(_address)
+        100_000_000
+      end
+    end.new
+    assert_raises(Sibit::Error, 'a two-way balance disagreement cannot resolve silently') do
+      Sibit::BestOf.new([low, high]).balance('1anyaddr')
+    end
+  end
+
+  def test_returns_strict_majority
+    high = Class.new do
+      def balance(_address)
+        100_000_000
+      end
+    end.new
+    low = Class.new do
+      def balance(_address)
+        0
+      end
+    end.new
+    assert_equal(
+      100_000_000,
+      Sibit::BestOf.new([high, high, low]).balance('1anyaddr'),
+      'a strict majority balance does not win the vote'
+    )
+  end
+
+  def test_push_stops_at_first_success
+    touched = []
+    second = Class.new do
+      define_method(:push) { |_hex| touched << :second }
+    end.new
+    first = Class.new do
+      def push(_hex); end
+    end.new
+    Sibit::BestOf.new([first, second]).push('deadbeef')
+    assert_empty(touched, 'push cannot broadcast to a second API after the first accepts it')
+  end
 end


### PR DESCRIPTION
`BestOf` is the component you reach for precisely when you want to cross-check money data across providers, yet it resolved disagreements by arbitrary tie-break. With an even split — two providers, or 2 vs 2 out of four — `max_by` returned whichever group it happened to see first, so a `balance()` of `100_000_000` against `0` quietly settled on one of them with no signal that the providers contradicted each other. That is the one situation the user picked `BestOf` to catch. It now demands a strict majority (more than half of the answers) and raises `Sibit::Error` naming every provider and its answer when no such majority exists.

`push()` no longer takes part in the vote either. Pushing is a side effect, so majority-voting on the providers' mostly-`nil` return values was meaningless: a single relay accepting the transaction while the rest errored still read as overall success only because the nils outvoted the error, and the semantics silently diverged from `FirstOf#push`. It now hands the transaction to each API in turn and stops at the first that accepts it, exactly like `FirstOf`.

New tests cover the no-majority disagreement (raises), the strict-majority win, and the push short-circuit that never reaches a second API once the first accepts. Existing agreement and all-fail tests still hold.

Closes #298