### PR TITLE
fix(tx): #321 reject cross-network target addresses in Output#script

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,8 +130,13 @@ Elegant/GoodMethodName:
     - test_extracts_hash160_from_p2wpkh
     - test_extracts_hash160_from_script
     - test_extracts_segwit_address_from_p2wpkh
+    - test_accepts_testnet_p2pkh_on_testnet
+    - test_accepts_testnet_p2sh_on_testnet
     - test_output_generates_p2sh_script
     - test_parses_p2pkh_script
+    - test_rejects_mainnet_p2pkh_on_testnet
+    - test_rejects_testnet_p2pkh_on_mainnet
+    - test_rejects_testnet_p2sh_on_mainnet
     - test_parses_p2wpkh_script
     - test_regtest_bech32_starts_with_bcrt1q
     - test_rejects_non_p2pkh_script

--- a/lib/sibit.rb
+++ b/lib/sibit.rb
@@ -152,7 +152,7 @@ class Sibit
         [pub, k.priv]
       end
     satoshi = satoshi(amount)
-    builder = TxBuilder.new
+    builder = TxBuilder.new(network)
     unspent = 0
     size = 100
     utxos = @api.utxos(sources.keys).sort_by { |u| [u[:hash], u[:index]] }

--- a/lib/sibit/tx.rb
+++ b/lib/sibit/tx.rb
@@ -24,9 +24,10 @@ class Sibit
 
     attr_reader :inputs, :outputs
 
-    def initialize
+    def initialize(network: :mainnet)
       @inputs = []
       @outputs = []
+      @network = network
     end
 
     def add_input(hash:, index:, script:, key:, value: 0)
@@ -34,7 +35,7 @@ class Sibit
     end
 
     def add_output(value, address)
-      @outputs << Output.new(value, address)
+      @outputs << Output.new(value, address, @network)
     end
 
     def hash
@@ -103,20 +104,33 @@ class Sibit
     class Output
       attr_reader :value
 
-      def initialize(value, address)
+      def initialize(value, address, network = :mainnet)
         @value = value
         @address = address
+        @network = network
       end
 
       def script
         return segwit_script if segwit?
-        return p2pkh_script if %w[00 6f].include?(version)
-        return p2sh_script if %w[05 c4].include?(version)
-        raise(Sibit::Error, "Address '#{@address}' has an unsupported version byte 0x#{version}")
+        return p2pkh_script if version == (@network == :mainnet ? '00' : '6f')
+        return p2sh_script if version == (@network == :mainnet ? '05' : 'c4')
+        raise(
+          Sibit::Error,
+          "Address '#{@address}' has version byte 0x#{version}, " \
+          "which does not belong to the #{@network} network"
+        )
       end
 
       def segwit?
-        @address.downcase.start_with?('bc1', 'tb1', 'bcrt1')
+        down = @address.downcase
+        return true if down.start_with?(*(@network == :mainnet ? ['bc1'] : %w[tb1 bcrt1]))
+        if down.start_with?(*(@network == :mainnet ? %w[tb1 bcrt1] : ['bc1']))
+          raise(
+            Sibit::Error,
+            "Address '#{@address}' is a Bech32 address of a different network than #{@network}"
+          )
+        end
+        false
       end
 
       def script_hex

--- a/lib/sibit/txbuilder.rb
+++ b/lib/sibit/txbuilder.rb
@@ -20,9 +20,10 @@ class Sibit
   class TxBuilder
     DUST = 546
 
-    def initialize
+    def initialize(network = :mainnet)
       @inputs = []
       @outputs = []
+      @network = network
     end
 
     def input
@@ -36,7 +37,7 @@ class Sibit
     end
 
     def tx(input_value:, leave_fee:, extra_fee:, change_address:)
-      txn = Tx.new
+      txn = Tx.new(network: @network)
       @inputs.each do |inp|
         txn.add_input(
           hash: inp.prev_out_hash,

--- a/test/test_tx.rb
+++ b/test/test_tx.rb
@@ -270,4 +270,80 @@ class TestTx < Minitest::Test
       'P2WPKH script must be 22 bytes (44 hex chars)'
     )
   end
+
+  def test_rejects_testnet_p2pkh_on_mainnet
+    tx = Sibit::Tx.new(network: :mainnet)
+    tx.add_output(10_000, 'mySAAMyKaEPVXE7FGpksaBk9i9WQt3QKi8')
+    assert_raises(Sibit::Error, 'a testnet P2PKH address cannot be paid silently on mainnet') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_testnet_p2sh_on_mainnet
+    tx = Sibit::Tx.new(network: :mainnet)
+    tx.add_output(10_000, '2MxSAy7KUcVkbyD22yDK2H8io9XKnewGGr3')
+    assert_raises(Sibit::Error, 'a testnet P2SH address cannot be paid silently on mainnet') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_testnet_segwit_on_mainnet
+    tx = Sibit::Tx.new(network: :mainnet)
+    tx.add_output(10_000, 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')
+    assert_raises(Sibit::Error, 'a testnet Bech32 address cannot be paid silently on mainnet') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_mainnet_p2pkh_on_testnet
+    tx = Sibit::Tx.new(network: :testnet)
+    tx.add_output(10_000, '1JvCsJtLmCxEk7ddZFnVkGXpr9uhxZPmJi')
+    assert_raises(Sibit::Error, 'a mainnet P2PKH address cannot be paid silently on testnet') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_rejects_mainnet_segwit_on_testnet
+    tx = Sibit::Tx.new(network: :testnet)
+    tx.add_output(10_000, 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4')
+    assert_raises(Sibit::Error, 'a mainnet Bech32 address cannot be paid silently on testnet') do
+      tx.outputs[0].script_hex
+    end
+  end
+
+  def test_accepts_testnet_p2pkh_on_testnet
+    tx = Sibit::Tx.new(network: :testnet)
+    tx.add_output(10_000, 'mySAAMyKaEPVXE7FGpksaBk9i9WQt3QKi8')
+    assert(
+      tx.outputs[0].script_hex.start_with?('76a914'),
+      'a testnet P2PKH address must build a P2PKH script on testnet'
+    )
+  end
+
+  def test_accepts_testnet_p2sh_on_testnet
+    tx = Sibit::Tx.new(network: :testnet)
+    tx.add_output(10_000, '2MxSAy7KUcVkbyD22yDK2H8io9XKnewGGr3')
+    assert(
+      tx.outputs[0].script_hex.start_with?('a914'),
+      'a testnet P2SH address must build a P2SH script on testnet'
+    )
+  end
+
+  def test_accepts_testnet_segwit_on_testnet
+    tx = Sibit::Tx.new(network: :testnet)
+    tx.add_output(10_000, 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx')
+    assert(
+      tx.outputs[0].script_hex.start_with?('0014'),
+      'a testnet Bech32 address must build a witness script on testnet'
+    )
+  end
+
+  def test_accepts_regtest_segwit_on_regtest
+    tx = Sibit::Tx.new(network: :regtest)
+    tx.add_output(10_000, 'bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080')
+    assert(
+      tx.outputs[0].script_hex.start_with?('0014'),
+      'a regtest Bech32 address must build a witness script on regtest'
+    )
+  end
 end


### PR DESCRIPTION
Fixes #321.

## Problem

`Sibit::Tx::Output#script` (`lib/sibit/tx.rb`) chose the output script shape from the address alone and never learned which network the payment belonged to. Version bytes `00` (mainnet P2PKH) and `6f` (testnet/regtest P2PKH) were treated as one case, `05` and `c4` (P2SH) as another, and `segwit?` matched `bc1`, `tb1` and `bcrt1` interchangeably.

As a result, a mainnet key paying an address copied from a testnet or regtest context produced a well-formed mainnet output that was signed and pushed with no warning — the payer got no signal the address advertised a different network.

## Fix

`pay()` already resolves the network from the source key, so this threads it through the build path:

- `TxBuilder.new(network)` stores the resolved network and hands it to `Tx.new(network:)`.
- `Tx#add_output` passes the network into each `Output`.
- `Output#script` / `Output#segwit?` now accept only `00`/`05` and a `bc1` prefix on mainnet, and only `6f`/`c4` with `tb1` or `bcrt1` otherwise, raising `Sibit::Error` on a mismatch.

This makes cross-network destinations fail-fast, matching the treatment of the sibling destination defects (#283, #289, #290).

## Tests

Added coverage in `test/test_tx.rb` for both directions:

- mainnet `Tx` rejects testnet P2PKH, testnet P2SH, and `tb1` Bech32 addresses;
- testnet `Tx` rejects mainnet P2PKH and `bc1` Bech32 addresses;
- testnet/regtest `Tx` still accepts their own P2PKH, P2SH, and Bech32 addresses.

All existing `test_tx` / `test_txbuilder` / `test_sibit` / `test_script` suites pass, and RuboCop is clean (new test names added to the `Elegant/GoodMethodName` allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3SatEY2GWBhBrNoFK76ah

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3SatEY2GWBhBrNoFK76ah)_