### PR TITLE
Print more details about the proxy

### DIFF
--- a/lib/sibit/bin.rb
+++ b/lib/sibit/bin.rb
@@ -145,10 +145,21 @@ class Sibit
         end
     end
 
+    def proxy
+      addr = options[:proxy] || ENV.fetch('SIBIT_PROXY', nil)
+      return if addr.nil?
+      if options[:proxy]
+        log.debug("Proxy found in the --proxy command line option (#{addr.length} symbols)")
+      else
+        log.debug("Proxy found in the SIBIT_PROXY env variable (#{addr.length} symbols)")
+      end
+      addr
+    end
+
     def client(dry: false)
-      proxy = options[:proxy] || ENV.fetch('SIBIT_PROXY', nil)
-      http = proxy ? Sibit::HttpProxy.new(proxy) : Sibit::Http.new
-      log.debug("Using proxy at #{http.host}") if proxy
+      addr = proxy
+      http = addr ? Sibit::HttpProxy.new(addr) : Sibit::Http.new
+      log.debug("Using proxy at #{http}") if addr
       api = Sibit::FirstOf.new(
         options[:api].flat_map { |a| a.split(',') }.map(&:downcase).map do |a|
           case a

--- a/lib/sibit/httpproxy.rb
+++ b/lib/sibit/httpproxy.rb
@@ -19,7 +19,13 @@ class Sibit
       @user, @password, @host, @port = parse(addr)
     end
 
-    attr_reader :host
+    def to_s
+      [
+        "#{@host}:#{@port}",
+        @user ? " as #{@user}" : '',
+        @password ? ", password #{'*' * @password.length}" : ''
+      ].join
+    end
 
     def client(uri)
       http = Net::HTTP.new(uri.host, uri.port, @host, Integer(@port, 10), @user, @password)

--- a/test/test_bin.rb
+++ b/test/test_bin.rb
@@ -126,4 +126,31 @@ class TestBin < Minitest::Test
     end
     assert_requested(stub)
   end
+
+  def test_reports_proxy_from_env_variable
+    assert_includes(
+      qbash(
+        'bin/sibit generate --verbose',
+        env: { 'SIBIT_PROXY' => 'jeff:swordfish@proxy.example.com:8080' }
+      ),
+      'Proxy found in the SIBIT_PROXY env variable (37 symbols)',
+      'dont report where the proxy address came from'
+    )
+  end
+
+  def test_reports_proxy_from_command_line_option
+    assert_includes(
+      qbash('bin/sibit generate --verbose --proxy proxy.example.com:8080'),
+      'Proxy found in the --proxy command line option (22 symbols)',
+      'dont report the --proxy option'
+    )
+  end
+
+  def test_reports_proxy_credentials_masked
+    assert_includes(
+      qbash('bin/sibit generate --verbose --proxy jeff:swordfish@proxy.example.com:8080'),
+      'Using proxy at proxy.example.com:8080 as jeff, password *********',
+      'dont report the proxy credentials'
+    )
+  end
 end

--- a/test/test_httpproxy.rb
+++ b/test/test_httpproxy.rb
@@ -90,4 +90,20 @@ class TestHttpProxy < Minitest::Test
       'proxy port with auth is wrong'
     )
   end
+
+  def test_prints_host_and_port
+    assert_equal(
+      'proxy.example.com:8080',
+      Sibit::HttpProxy.new('proxy.example.com:8080').to_s,
+      'proxy without credentials is printed wrong'
+    )
+  end
+
+  def test_prints_credentials_with_masked_password
+    assert_equal(
+      'proxy.example.com:8080 as jeff, password *********',
+      Sibit::HttpProxy.new('jeff:swordfish@proxy.example.com:8080').to_s,
+      'proxy with credentials is printed wrong'
+    )
+  end
 end


### PR DESCRIPTION
The debug log now tells where the proxy address came from, either the `--proxy` option or the `SIBIT_PROXY` env variable, and how many symbols it has. It also prints the port next to the host, and, when the address carries credentials, the user name plus one asterisk per letter of the password.

Before this, the log only said `Using proxy at 45.90.197.209` — no port, no hint about the source. That made it hard to tell whether the address was picked up at all and whether it was parsed the way it looked.

`HttpProxy#to_s` renders the whole thing now, so `attr_reader :host` is gone.

Closes #337